### PR TITLE
Fixed a memory leak in RmtView.cpp. m_pen1 was not deleted, on every …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-cpp_src/Debug
-cpp_src/Release
+.vs/
 

--- a/cpp_src/.gitignore
+++ b/cpp_src/.gitignore
@@ -1,0 +1,6 @@
+Debug/
+Release/
+.vs
+*.ncb
+*.aps
+*.suo

--- a/cpp_src/Atari6502.cpp
+++ b/cpp_src/Atari6502.cpp
@@ -11,6 +11,8 @@
 #include <fstream>	/* needed for Load/SaveBinaryFile */
 using namespace std;
 #include "Atari6502.h"
+#include "r_music.h"
+#include "global.h"
 
 typedef void (* C6502_Initialise_PROC)(BYTE*);
 typedef int  (* C6502_JSR_PROC)(WORD* , BYTE* , BYTE* , BYTE* , int* );

--- a/cpp_src/Atari6502.h
+++ b/cpp_src/Atari6502.h
@@ -9,17 +9,6 @@
 
 #include "Tuning.h"
 
-extern double g_tuning;
-extern BOOL g_ntsc;
-
-extern HWND g_hwnd;
-
-extern int volatile g_prove;
-extern unsigned char g_atarimem[65536];
-
-#define SONGTRACKS	8
-extern int g_rmtinstr[SONGTRACKS];
-
 //bass16bit low byte, bass 0C, bass 0E, clean tones 0A and 0,2,4,8, bass16bit hi byte, this might require different addresses? What is this even used for anyway?
 #define RMT_FRQTABLES	0xB000				
 
@@ -40,31 +29,24 @@ extern int g_rmtinstr[SONGTRACKS];
 #define MAXSCREENCYCLES_NTSC	114*262
 #define MAXSCREENCYCLES_PAL 	114*312
 
-void Memory_Clear();
-int LoadBinaryBlock(ifstream& in,unsigned char* memory,WORD& fromadr, WORD& toadr);
-int LoadBinaryFile(char *fname, unsigned char *memory,WORD& minadr,WORD& maxadr);
-int LoadDataAsBinaryFile(unsigned char *data, WORD size, unsigned char *memory,WORD& minadr,WORD& maxadr);
-int SaveBinaryBlock(ofstream& out,unsigned char* memory,WORD fromadr,WORD toadr,BOOL ffffhead);
+extern void Memory_Clear();
+extern int LoadBinaryBlock(ifstream& in,unsigned char* memory,WORD& fromadr, WORD& toadr);
+extern int LoadBinaryFile(char *fname, unsigned char *memory,WORD& minadr,WORD& maxadr);
+extern int LoadDataAsBinaryFile(unsigned char *data, WORD size, unsigned char *memory,WORD& minadr,WORD& maxadr);
+extern int SaveBinaryBlock(ofstream& out,unsigned char* memory,WORD fromadr,WORD toadr,BOOL ffffhead);
 
-int Atari_LoadRMTRoutines();
-int Atari_InitRMTRoutine();
-void Atari_PlayRMT();
-void Atari_Silence();
-void Atari_SetTrack_NoteInstrVolume(int t,int n,int i,int v);
-void Atari_SetTrack_Volume(int t,int v);
-void Atari_InstrumentTurnOff(int instr);
+extern int Atari_LoadRMTRoutines();
+extern int Atari_InitRMTRoutine();
+extern void Atari_PlayRMT();
+extern void Atari_Silence();
+extern void Atari_SetTrack_NoteInstrVolume(int t,int n,int i,int v);
+extern void Atari_SetTrack_Volume(int t,int v);
+extern void Atari_InstrumentTurnOff(int instr);
+
+extern int Atari6502_Init();
+extern void Atari6502_DeInit();
 
 //hack: optionally display the RMT driver version using the plaintext data from tracker.obx
-void Get_Driver_Version();
-
-extern HINSTANCE g_c6502_dll;
-extern BOOL volatile g_is6502;
-extern CString g_about6502;
-
-extern CString g_driverversion;
-
-extern CString g_prgpath;
-
-extern void TextXY(char *txt,int x,int y,int c);
+extern void Get_Driver_Version();
 
 #endif

--- a/cpp_src/Global.cpp
+++ b/cpp_src/Global.cpp
@@ -1,0 +1,573 @@
+#include "stdafx.h"
+#include "Rmt.h"
+#include "XPokey.h"
+#include "RmtView.h"
+#include "Atari6502.h"
+#include "global.h"
+
+// Helper defines to make the code a bit more readable
+#define SCALE(x) ((x) * sp) / 100
+
+
+
+unsigned char g_atarimem[65536];
+char g_debugmem[65536];	//debug display of g_atarimem bytes directly, slow and terrible, do not use unless there is a purpose for it 
+
+unsigned char SAPRSTREAM[0xFFFFFF];	//SAP-R Dumper memory, TODO: assign memory dynamically instead, however this doesn't seem to harm anything for now
+
+int SAPRDUMP = 0;		//0, the SAPR dumper is disabled; 1, output is currently recorded to memory; 2, recording is finished and will be written to sap file; 3, flag engage the SAPR dumper
+int framecount = 0;		//SAPR dumper frame counter used for calculations and memory allignment with bytes 
+
+int Hexstr(char* txt, int len)
+{
+	int r = 0;
+	char a;
+	int i;
+	for (i = 0; (a = txt[i]) && i < len; i++)
+	{
+		if (a >= '0' && a <= '9')
+			r = (r << 4) + (a - '0');
+		else
+			if (a >= 'A' && a <= 'F')
+				r = (r << 4) + (a - 'A' + 10);
+			else
+			{
+				if (i == 0) r = -1; //nothing
+				return r;
+			}
+	}
+	if (i == 0) r = -1; //nothing
+	return r;
+}
+
+BOOL g_closeapplication = 0;
+CDC* g_mem_dc = NULL;
+CDC* g_gfx_dc = NULL;
+
+int g_width = 0;
+int g_height = 0;
+int g_tracklines = 8;
+int g_scaling_percentage = 100;
+
+//best known compromise for both regions, they produce identical tables
+double g_basetuning = (g_ntsc) ? 444.895778867913 : 440.83751645933;
+int g_basenote = 3;	//3 = A-
+
+//ratio used for each note => NOTE_L / NOTE_R, must be treated as doubles!!!
+double g_UNISON = 1;
+double g_MIN_2ND = 1;
+double g_MAJ_2ND = 1;
+double g_MIN_3RD = 1;
+double g_MAJ_3RD = 1;
+double g_PERF_4TH = 1;
+double g_TRITONE = 1;
+double g_PERF_5TH = 1;
+double g_MIN_6TH = 1;
+double g_MAJ_6TH = 1;
+double g_MIN_7TH = 1;
+double g_MAJ_7TH = 1;
+double g_OCTAVE = 2;
+
+//ratio left
+int g_UNISON_L = 1;
+int g_MIN_2ND_L = 40;
+int g_MAJ_2ND_L = 10;
+int g_MIN_3RD_L = 20;
+int g_MAJ_3RD_L = 5;
+int g_PERF_4TH_L = 4;
+int g_TRITONE_L = 60;
+int g_PERF_5TH_L = 3;
+int g_MIN_6TH_L = 30;
+int g_MAJ_6TH_L = 5;
+int g_MIN_7TH_L = 30;
+int g_MAJ_7TH_L = 15;
+int g_OCTAVE_L = 2;
+
+//ratio right
+int g_UNISON_R = 1;
+int g_MIN_2ND_R = 38;
+int g_MAJ_2ND_R = 9;
+int g_MIN_3RD_R = 17;
+int g_MAJ_3RD_R = 4;
+int g_PERF_4TH_R = 3;
+int g_TRITONE_R = 43;
+int g_PERF_5TH_R = 2;
+int g_MIN_6TH_R = 19;
+int g_MAJ_6TH_R = 3;
+int g_MIN_7TH_R = 17;
+int g_MAJ_7TH_R = 8;
+int g_OCTAVE_R = 1;
+
+//each preset is assigned to a number. 0 means no Temperament, any value that is not assigned defaults to custom
+int g_temperament = 0;
+
+
+
+
+HWND g_hwnd = NULL;
+HWND g_viewhwnd = NULL;
+
+HINSTANCE g_c6502_dll = NULL;
+BOOL volatile g_is6502 = 0;
+CString g_aboutpokey;
+CString g_about6502;
+CString g_driverversion;
+
+BOOL g_changes = 0;	//have there been any changes in the module?
+
+int g_focus;
+int g_shiftkey;
+int g_controlkey;
+int g_altkey;	//unfinished implementation, doesn't work yet for some reason
+
+int g_tracks4_8;
+BOOL volatile g_screenupdate = 0;
+BOOL volatile g_invalidatebytimer = 0;
+int volatile g_screena;
+int volatile g_screenwait;
+BOOL volatile g_rmtroutine;
+BOOL volatile g_timerroutineprocessed;
+
+int volatile g_prove;			//test notes without editing (0 = off, 1 = mono, 2 = stereo)
+int volatile g_respectvolume;	//does not change the volume if it is already there
+
+WORD g_rmtstripped_adr_module;	//address for export RMT stripped file
+BOOL g_rmtstripped_sfx;			//sfx offshoot RMT stripped file
+BOOL g_rmtstripped_gvf;			//gvs GlobalVolumeFade for feat
+BOOL g_rmtstripped_nos;			//nos NoStartingSongline for feat
+
+CString g_rmtmsxtext;
+CString g_expasmlabelprefix;	//label prefix for export ASM simple notation
+
+int g_activepart;			//0 info, 1 edittracks, 2 editinstruments, 3 song
+int g_active_ti;			//1 tracks, 2 instrs
+
+BOOL is_editing_instr;		//0 no, 1 instrument name is edited
+BOOL is_editing_infos;		//0 no, 1 song name is edited
+
+int g_tracklinehighlight = 8;	//line highlighted every x lines
+BOOL g_tracklinealtnumbering = 0; //alternative way of line numbering in tracks
+int g_linesafter;			//number of lines to scroll after inserting a note (initializes in CSong :: Clear)
+BOOL g_ntsc = 0;				//NTSC (60Hz)
+BOOL g_nohwsoundbuffer = 0;	//Don't use hardware soundbuffer
+int g_cursoractview = 0;		//default position, line 0
+
+BOOL g_displayflatnotes = 0;	//flats instead of sharps
+BOOL g_usegermannotation = 0;	//H notes instead of B
+
+int g_channelon[SONGTRACKS];
+int g_rmtinstr[SONGTRACKS];
+
+BOOL g_viewmaintoolbar = 1;		//1 yes, 0 no
+BOOL g_viewblocktoolbar = 1;	//1 yes, 0 no
+BOOL g_viewstatusbar = 1;		//1 yes, 0 no
+BOOL g_viewplaytimecounter = 1;	//1 yes, 0 no
+BOOL g_viewanalyzer = 1;		//1 yes, 0 no
+BOOL g_viewpokeyregs = 1;		//1 yes, 0 no
+BOOL g_viewinstractivehelp = 1;	//1 yes, 0 no
+
+long g_playtime = 1;	//1 yes, 0 no
+
+UINT g_mousebutt = 0;			//mouse button
+
+CTrackClipboard g_trackcl;
+
+CString g_prgpath;					//path to the directory from which the program was started (including a slash at the end)
+CString g_lastloadpath_songs;		//the path of the last song loaded
+CString g_lastloadpath_instruments; //the path of the last instrument loaded
+CString g_lastloadpath_tracks;		//the path of the last track loaded
+
+CString g_path_songs;		//default path for songs
+CString g_path_instruments;	//default path for instruments
+CString g_path_tracks;		//default path for tracks
+
+int g_keyboard_layout = 0;	//1 yes, 0 no, not be useful anymore... should be deleted
+BOOL g_keyboard_swapenter = 0;	//1 yes, 0 no, probably not needed anymore but will be kept for now
+BOOL g_keyboard_playautofollow = 1;	//1 yes, 0 no
+BOOL g_keyboard_updowncontinue = 1;	//1 yes, 0 no
+BOOL g_keyboard_rememberoctavesandvolumes = 1;	//1 yes, 0 no
+BOOL g_keyboard_escresetatarisound = 1;	//1 yes, 0 no
+BOOL g_keyboard_askwhencontrol_s = 1;	//1 yes, 0 no
+
+int g_midi_notech[16];			//last recorded notes on each MIDI channel
+int g_midi_voluch[16];			//note volume on individual MIDI channels
+int g_midi_instch[16];			//last set instrument numbers on individual MIDI channels
+
+BOOL g_midi_tr = 0;
+int g_midi_volumeoffset = 1;	//starts from volume 1 by default
+BOOL g_midi_noteoff = 0;		//by default, noteoff is turned off
+
+//----
+
+void TextXY(char* txt, int x, int y, int color)
+{
+	int sp = g_scaling_percentage;
+
+	char charToDraw;
+	color = color << 4;
+	for (int i = 0; charToDraw = (txt[i]); i++, x += 8)
+	{
+		if (charToDraw == 32) continue;	// Don't draw the space
+		g_mem_dc->StretchBlt(SCALE(x), SCALE(y), SCALE(8), SCALE(16), g_gfx_dc, (charToDraw & 0x7f) << 3, color, 8, 16, SRCCOPY);
+	}
+}
+
+void TextXYSelN(char* txt, int n, int x, int y, int color)
+{
+	//the index character n will have a "select" color, the rest c
+	int sp = g_scaling_percentage;
+	char charToDraw;
+	color = color << 4;
+
+	int col = (g_prove) ? COLOR_SELECTED_PROVE : COLOR_SELECTED;
+
+	int i;
+	for (i = 0; charToDraw = (txt[i]); i++, x += 8)
+	{
+		g_mem_dc->StretchBlt(SCALE(x), SCALE(y), SCALE(8), SCALE(16), g_gfx_dc, (charToDraw & 0x7f) << 3, (i == n) ? col * 16 : color, 8, 16, SRCCOPY);
+	}
+	if (i == n) //the first character after the end of the string
+		g_mem_dc->StretchBlt(SCALE(x), SCALE(y), SCALE(8), SCALE(16), g_gfx_dc, 32 << 3, col * 16, 8, 16, SRCCOPY);
+}
+
+// Draw 8x16 chars with given color array per char position
+void TextXYCol(char* txt, int x, int y, char* col)
+{
+	int sp = g_scaling_percentage;
+	char charToDraw;
+	for (int i = 0; charToDraw = (txt[i]); i++, x += 8)
+	{
+		g_mem_dc->StretchBlt(SCALE(x), SCALE(y), SCALE(8), SCALE(16), g_gfx_dc, (charToDraw & 0x7f) << 3, col[i] << 4, 8, 16, SRCCOPY);
+	}
+}
+
+// Draw 8x16 chars vertically (one below the other)
+void TextDownXY(char* txt, int x, int y, int color)
+{
+	int sp = g_scaling_percentage;
+	char charToDraw;
+	color = color << 4;	// 16 pixels height
+	for (int i = 0; charToDraw = (txt[i]); i++, y += 16)
+	{
+		g_mem_dc->StretchBlt(SCALE(x), SCALE(y), SCALE(8), SCALE(16), g_gfx_dc, (charToDraw & 0x7f) << 3, color, 8, 16, SRCCOPY);
+	}
+}
+
+void NumberMiniXY(BYTE num, int x, int y, int color)
+{
+	int sp = g_scaling_percentage;
+	color = 112 + (color << 3);
+	g_mem_dc->StretchBlt(SCALE(x), SCALE(y), SCALE(8), SCALE(8), g_gfx_dc, (num & 0xf0) >> 1, color, 8, 8, SRCCOPY);
+	g_mem_dc->StretchBlt(SCALE(x+8), SCALE(y), SCALE(8), SCALE(8), g_gfx_dc, (num & 0x0f) << 3, color, 8, 8, SRCCOPY);
+}
+
+void TextMiniXY(char* txt, int x, int y, int color)
+{
+	int sp = g_scaling_percentage;
+	char charToDraw;
+	color = 112 + (color << 3);
+	for (int i = 0; charToDraw = (txt[i]); i++, x += 8)
+	{
+		if (charToDraw == 32) continue;
+		g_mem_dc->StretchBlt(SCALE(x), SCALE(y), SCALE(8), SCALE(8), g_gfx_dc, (charToDraw & 0x7f) << 3, color, 8, 8, SRCCOPY);
+	}
+}
+
+void IconMiniXY(int icon, int x, int y)
+{
+	int sp = g_scaling_percentage;
+	static int c = 128 - 6;
+	if (icon >= 1 && icon <= 4) g_mem_dc->StretchBlt(SCALE(x), SCALE(y), SCALE(32), SCALE(6), g_gfx_dc, (icon - 1) * 32, c, 32, 6, SRCCOPY);
+}
+
+void GetTracklineText(char* dest, int line)
+{
+	if (line < 0 || line>0xff) { dest[0] = 0; return; }
+	if (g_tracklinealtnumbering)
+	{
+		int a = line / g_tracklinehighlight;
+		if (a >= 35) a = (a - 35) % 26 + 'a' - '9' + 1;
+		int b = line % g_tracklinehighlight;
+		if (b >= 35) b = (b - 35) % 26 + 'a' - '9' + 1;
+		if (a <= 8)
+			a = '1' + a;
+		else
+			a = 'A' - 9 + a;
+		if (b <= 8)
+			b = '1' + b;
+		else
+			b = 'A' - 9 + b;
+		dest[0] = a;
+		dest[1] = b;
+		dest[2] = 0;
+	}
+	else
+		sprintf(dest, "%02X", line);
+}
+
+void UpdateShiftControlKeys()
+{
+	g_shiftkey = (GetAsyncKeyState(VK_SHIFT) != NULL);
+	g_controlkey = (GetAsyncKeyState(VK_CONTROL) != NULL);
+	g_altkey = (GetAsyncKeyState(VK_MENU) != NULL);
+}
+
+BOOL IsnotMovementVKey(int vk)
+{
+	//returns 1 if it is not a scroll key
+	return (vk != VK_RIGHT && vk != VK_LEFT && vk != VK_UP && vk != VK_DOWN && vk != VK_TAB && vk != 13 && vk != VK_HOME && vk != VK_END && vk != VK_PAGE_UP && vk != VK_PAGE_DOWN && vk != VK_CAPITAL);
+}
+
+int EditText(int vk, int shift, int control, char* txt, int& cur, int max)
+{
+	//returns 1 if TAB or ENTER was pressed
+	max--;
+	if (vk == 8) //VK_BACKSPACE
+	{
+		if (cur > 0)
+		{
+			cur--;
+			for (int j = cur; j <= max - 1; j++) txt[j] = txt[j + 1];
+			txt[max] = ' ';
+		}
+	}
+	else if (vk == VK_TAB || vk == 13)		//VK_ENTER
+	{
+		return 1;
+	}
+	else if (vk == VK_INSERT)
+	{
+		for (int j = max - 1; j >= cur; j--) txt[j + 1] = txt[j];
+		txt[cur] = ' ';
+	}
+	else if (vk == VK_DELETE)
+	{
+		for (int j = cur; j <= max - 1; j++) txt[j] = txt[j + 1];
+		txt[max] = ' ';
+	}
+	else
+	{
+		if (control) return 0;
+		char a = 0;
+		if (vk >= 65 && vk <= 90) { a = (shift) ? vk : vk + 32; }		//letters - uppercase with SHIFT
+		else if (vk >= 48 && vk <= 57) { a = (shift) ? *(")!@#$%^&*(" + vk - 48) : vk; }			//numbers - special characters with SHIFT
+		else if (vk == ' ')			a = ' ';	//space
+		else if (vk == 189)	a = (shift) ? '_' : '-';
+		else if (vk == 187)	a = (shift) ? '+' : '=';
+		else if (vk == 219)	a = (shift) ? '{' : '[';
+		else if (vk == 221)	a = (shift) ? '}' : ']';
+		else if (vk == 186)	a = (shift) ? ':' : ';';
+		else if (vk == 222)	a = (shift) ? '"' : '\'';
+		else if (vk == 188)	a = (shift) ? '<' : ',';
+		else if (vk == 190)	a = (shift) ? '>' : '.';
+		else if (vk == 191)	a = (shift) ? '?' : '/';
+		else if (vk == 220)	a = (shift) ? '|' : '\\';
+		else if (vk == VK_RIGHT)
+		{
+			if (cur < max) cur++;
+		}
+		else if (vk == VK_LEFT)
+		{
+			if (cur > 0) cur--;
+		}
+		else if (vk == VK_HOME) cur = 0;
+		else if (vk == VK_END)
+		{
+			int j;
+			for (j = max; j >= 0 && (txt[j] == ' '); j--);
+			cur = (j < max) ? j + 1 : max;
+		}
+
+		if (a > 0)
+		{
+			for (int j = max - 1; j >= cur; j--) txt[j + 1] = txt[j];
+			txt[cur] = a;
+			if (cur < max) cur++;
+		}
+	}
+	return 0;
+}
+
+void WaitForTimerRoutineProcessed()
+{
+	g_timerroutineprocessed = 0;
+	while (!g_timerroutineprocessed) Sleep(1);		//waiting
+}
+
+void StrToAtariVideo(char* txt, int count)
+{
+	char a;
+	for (int i = 0; i < count; i++)
+	{
+		a = txt[i] & 0x7f;
+		if (a < 32) a = 0;
+		else
+			if (a < 96) a -= 32;
+		txt[i] = a;
+	}
+}
+
+//----
+
+void SetChannelOnOff(int ch, int onoff)
+{
+	if (ch < 0)
+	{	//all channels
+		if (onoff >= 0)
+			for (int i = 0; i < SONGTRACKS; i++) g_channelon[i] = onoff;	//Settings
+		else
+			for (int i = 0; i < SONGTRACKS; i++) g_channelon[i] ^= 1;	//invert
+	}
+	else
+		if (ch < SONGTRACKS)
+		{	//just that one
+			if (onoff >= 0)
+				g_channelon[ch] = onoff;	//Settings
+			else
+				g_channelon[ch] ^= 1;	//invert
+		}
+}
+
+int GetChannelOnOff(int ch)
+{
+	return g_channelon[ch];
+}
+
+void SetChannelSolo(int ch)
+{
+	int on = GetChannelOnOff(ch);
+	if (!on)
+	{
+	Channel_SOLO:
+		SetChannelOnOff(-1, 0);	//all off
+		SetChannelOnOff(ch, 1);	//and solo only active
+	}
+	else
+	{
+		for (int i = 0; i < g_tracks4_8; i++)
+		{
+			if (i != ch && GetChannelOnOff(i)) goto Channel_SOLO;
+		}
+		SetChannelOnOff(-1, 1);	//turn them all on
+	}
+}
+
+//debug display of g_atarimem bytes directly, slow and terrible, do not use unless there is a purpose for it 
+void GetAtariMemHexStr(int adr, int len)
+{
+	unsigned int a = 0;
+	char c[8] = { 0 };
+	memset(g_debugmem, 0, 65536);
+	for (int i = 0; i < len; i++)
+	{
+		a = g_atarimem[adr + i];
+		sprintf(c, "$%x, ", a);
+		g_debugmem[i * 4] = c[0];	//$
+		//force uppercase on characters "a" to "f"
+		if (c[1] >= 0x61 && c[1] < 0x67) c[1] -= 0x20;
+		if (c[2] >= 0x61 && c[2] < 0x67) c[2] -= 0x20;
+		if (a > 0xF)	//0x10 and above
+		{
+			g_debugmem[(i * 4) + 1] = c[1];	//nybble 1
+			g_debugmem[(i * 4) + 2] = c[2];	//nybble 2
+		}
+		else	//single digit hex character, add padding 0
+		{
+			g_debugmem[(i * 4) + 1] = '0';	//nybble 1
+			g_debugmem[(i * 4) + 2] = c[1];	//nybble 2
+		}
+		if (i != len - 1) g_debugmem[(i * 4) + 3] = ',';
+		else g_debugmem[(i * 4) + 3] = ' ';	//, or space if last character
+	}
+}
+
+//----
+
+const char keynotes[256] =
+{
+	//0
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, 27, -1,
+	//50
+	13, 15, -1, 18, 20, 22, -1, 25, -1, -1,
+	-1, -1, -1, -1, -1, -1,  7,  4,  3, 16,
+	-1,  6,  8, 24, 10, -1, 13, 11,  9, 26,
+	28, 12, 17,  1, 19, 23,  5, 14,  2, 21,
+	0, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	//100
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	//150
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, 15, 30, 12, -1,
+	14, 16, -1, -1, -1, -1, -1, -1, -1, -1,
+	//200
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, 29,
+	-1, 31, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	//250
+	-1, -1, -1, -1, -1, -1
+};
+
+const char keynumbs[256] =
+{
+	//0
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, -1, -1,
+	//64
+	-1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	//128
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	//192
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+};
+
+const char keynumblock09[256] =
+{
+	//0
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	//64
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	//128
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	//192
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+};
+
+char NoteKey(int vk) { return keynotes[vk]; };
+char NumbKey(int vk) { return keynumbs[vk]; };
+char Numblock09Key(int vk) { return keynumblock09[vk]; };
+

--- a/cpp_src/Rmt.vcxproj
+++ b/cpp_src/Rmt.vcxproj
@@ -19,13 +19,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>Dynamic</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
     <EnableUnitySupport>true</EnableUnitySupport>
@@ -141,6 +141,10 @@
       <PreprocessorDefinitions>_AFXDLL;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <Culture>0x0405</Culture>
     </ResourceCompile>
+    <PostBuildEvent>
+      <Command>
+      </Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Atari6502.cpp">
@@ -189,8 +193,12 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NDEBUG;WIN32;_WINDOWS;NO_CONSOL_SOUND;NO_VOL_ONLY;STEREO;_MBCS;_AFXDLL</PreprocessorDefinitions>
       <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</BrowseInformation>
     </ClCompile>
-    <ClCompile Include="getopt.cpp" />
-    <ClCompile Include="importdlgs.cpp">
+    <ClCompile Include="getopt.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="Global.cpp" />
+    <ClCompile Include="ImportDlgs.cpp">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">_DEBUG;WIN32;_WINDOWS;NO_CONSOL_SOUND;NO_VOL_ONLY;STEREO;_MBCS;_AFXDLL</PreprocessorDefinitions>
       <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">EnableFastChecks</BasicRuntimeChecks>
       <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</BrowseInformation>
@@ -199,6 +207,8 @@
     </ClCompile>
     <ClCompile Include="lzss_sap.cpp">
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">stdc17</LanguageStandard_C>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="MainFrm.cpp">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">_DEBUG;WIN32;_WINDOWS;NO_CONSOL_SOUND;NO_VOL_ONLY;STEREO;_MBCS;_AFXDLL</PreprocessorDefinitions>
@@ -242,8 +252,13 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NDEBUG;WIN32;_WINDOWS;NO_CONSOL_SOUND;NO_VOL_ONLY;STEREO;_MBCS;_AFXDLL</PreprocessorDefinitions>
       <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</BrowseInformation>
     </ClCompile>
-    <ClCompile Include="libfmemopen.cpp" />
-    <ClCompile Include="Tuning.cpp" />
+    <ClCompile Include="libfmemopen.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="Tuning.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="StdAfx.cpp">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">_DEBUG;WIN32;_WINDOWS;NO_CONSOL_SOUND;NO_VOL_ONLY;STEREO;_MBCS;_AFXDLL</PreprocessorDefinitions>
       <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">EnableFastChecks</BasicRuntimeChecks>
@@ -303,6 +318,38 @@
     <Image Include="res\toolbarp.bmp" />
   </ItemGroup>
   <ItemGroup>
+    <CopyFileToFolders Include="..\RMT\RMT Binaries\tracker.obx">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <FileType>Document</FileType>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)/RMT Binaries</DestinationFolders>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)/RMT Binaries</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="..\RMT\RMT Binaries\VUPlayer (LZSS Export).obx">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)/RMT Binaries</DestinationFolders>
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)/RMT Binaries</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="..\RMT\sa_c6502.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="..\RMT\sa_pokey.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
+    </CopyFileToFolders>
     <None Include="res\cur00001.cur" />
     <None Include="res\cur00002.cur" />
     <None Include="res\cur00003.cur" />

--- a/cpp_src/Rmt.vcxproj.filters
+++ b/cpp_src/Rmt.vcxproj.filters
@@ -13,78 +13,97 @@
       <UniqueIdentifier>{9f40edfd-959f-43b9-98e8-183315831f97}</UniqueIdentifier>
       <Extensions>ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe</Extensions>
     </Filter>
+    <Filter Include="Copy to Build Folder">
+      <UniqueIdentifier>{58195311-11eb-48ee-aea7-c95cae22689d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Copy to Build Folder\RMT Binaries">
+      <UniqueIdentifier>{a2f10bad-f640-4755-9632-a9eee2b9728d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Dialogs">
+      <UniqueIdentifier>{0d6bbee4-a8b9-457f-90d9-73664e410b59}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Helpers">
+      <UniqueIdentifier>{4139ef6f-85a8-4e4f-aa78-fb5152aa902a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\SAP-R Compressor">
+      <UniqueIdentifier>{b1ac240f-8bfa-4b7f-9f1a-67e475c4a76e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Tuning">
+      <UniqueIdentifier>{4c4d791e-b9e3-49ec-ba38-fb7c8e30b9b4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Sound Generator">
+      <UniqueIdentifier>{973e7050-b72b-497e-bb78-59b87397d694}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\RMT Interface">
+      <UniqueIdentifier>{c90897da-fb9a-4282-a4d0-c209c89b0507}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="Atari6502.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ConfigDlg.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="EffectsDlg.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ExportDlgs.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FileNewDlg.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FilePathDlg.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="MainFrm.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Rmt.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="RmtDoc.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="RmtMidi.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="RmtView.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="StdAfx.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="XPokey.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="importdlgs.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="r_music.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Tuning.cpp">
+    <ClCompile Include="Global.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="TuningDlg.cpp">
-      <Filter>Source Files</Filter>
+    <ClCompile Include="ConfigDlg.cpp">
+      <Filter>Source Files\Dialogs</Filter>
     </ClCompile>
-    <ClCompile Include="lzss_sap.cpp">
-      <Filter>Source Files</Filter>
+    <ClCompile Include="EffectsDlg.cpp">
+      <Filter>Source Files\Dialogs</Filter>
     </ClCompile>
-    <ClCompile Include="getopt.cpp">
-      <Filter>Source Files</Filter>
+    <ClCompile Include="ExportDlgs.cpp">
+      <Filter>Source Files\Dialogs</Filter>
+    </ClCompile>
+    <ClCompile Include="FileNewDlg.cpp">
+      <Filter>Source Files\Dialogs</Filter>
+    </ClCompile>
+    <ClCompile Include="FilePathDlg.cpp">
+      <Filter>Source Files\Dialogs</Filter>
+    </ClCompile>
+    <ClCompile Include="ImportDlgs.cpp">
+      <Filter>Source Files\Dialogs</Filter>
     </ClCompile>
     <ClCompile Include="libfmemopen.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="getopt.cpp">
+      <Filter>Source Files\Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="lzss_sap.cpp">
+      <Filter>Source Files\SAP-R Compressor</Filter>
+    </ClCompile>
+    <ClCompile Include="RmtMidi.cpp">
+      <Filter>Source Files\Dialogs</Filter>
+    </ClCompile>
+    <ClCompile Include="Tuning.cpp">
+      <Filter>Source Files\Tuning</Filter>
+    </ClCompile>
+    <ClCompile Include="TuningDlg.cpp">
+      <Filter>Source Files\Tuning</Filter>
+    </ClCompile>
+    <ClCompile Include="XPokey.cpp">
+      <Filter>Source Files\Sound Generator</Filter>
+    </ClCompile>
+    <ClCompile Include="Rmt.cpp">
+      <Filter>Source Files\RMT Interface</Filter>
+    </ClCompile>
+    <ClCompile Include="RmtDoc.cpp">
+      <Filter>Source Files\RMT Interface</Filter>
+    </ClCompile>
+    <ClCompile Include="RmtView.cpp">
+      <Filter>Source Files\RMT Interface</Filter>
+    </ClCompile>
+    <ClCompile Include="Atari6502.cpp">
+      <Filter>Source Files\Sound Generator</Filter>
+    </ClCompile>
+    <ClCompile Include="MainFrm.cpp">
+      <Filter>Source Files\RMT Interface</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="Rmt.rc">
-      <Filter>Source Files</Filter>
-    </ResourceCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="Atari6502.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="ConfigDlg.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -98,9 +117,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="FilePathDlg.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="MainFrm.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Resource.h">
@@ -121,9 +137,6 @@
     <ClInclude Include="StdAfx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="XPokey.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="global.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -131,12 +144,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="r_music.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Tuning.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="TuningDlg.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="getopt.h">
@@ -147,6 +154,21 @@
     </ClInclude>
     <ClInclude Include="libfmemopen.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Tuning.h">
+      <Filter>Source Files\Tuning</Filter>
+    </ClInclude>
+    <ClInclude Include="TuningDlg.h">
+      <Filter>Source Files\Tuning</Filter>
+    </ClInclude>
+    <ClInclude Include="XPokey.h">
+      <Filter>Source Files\Sound Generator</Filter>
+    </ClInclude>
+    <ClInclude Include="Atari6502.h">
+      <Filter>Source Files\Sound Generator</Filter>
+    </ClInclude>
+    <ClInclude Include="MainFrm.h">
+      <Filter>Source Files\RMT Interface</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -207,5 +229,24 @@
     <Text Include="todo eng.txt" />
     <Text Include="trackerdesign_x_uzsi.txt" />
     <Text Include="RMT CHANGES WIP.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <CopyFileToFolders Include="..\RMT\RMT Binaries\tracker.obx">
+      <Filter>Copy to Build Folder\RMT Binaries</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="..\RMT\RMT Binaries\VUPlayer (LZSS Export).obx">
+      <Filter>Copy to Build Folder\RMT Binaries</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="..\RMT\sa_c6502.dll">
+      <Filter>Copy to Build Folder</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="..\RMT\sa_pokey.dll">
+      <Filter>Copy to Build Folder</Filter>
+    </CopyFileToFolders>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Rmt.rc">
+      <Filter>Source Files\RMT Interface</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/cpp_src/RmtView.cpp
+++ b/cpp_src/RmtView.cpp
@@ -13,6 +13,7 @@
 #include "FileNewDlg.h"
 #include "r_music.h"
 #include "TuningDlg.h"
+#include "Atari6502.h"
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -235,6 +236,8 @@ CRmtView::CRmtView()
 	g_screenwait=2;		//2 fifties
 	m_width = 0;
 	m_height = 0;
+
+	m_pen1 = NULL;
 }
 
 CRmtView::~CRmtView()
@@ -812,6 +815,7 @@ bool CRmtView::Resize(int width, int height)
 		m_mem_dc.SelectObject(&m_mem_bitmap);
 		g_mem_dc = &m_mem_dc;
 		g_tracklines = (g_height - (TRACKS_Y + 3 * 16) - 40) / 16;	//number of track lines that can be displayed based on the window height
+		if (m_pen1) delete m_pen1;
 		m_pen1 = new CPen(PS_SOLID, 1, RGBLINES);	
 		m_penorig = g_mem_dc->SelectObject(m_pen1);
 		m_mem_dc.FillSolidRect(0, 0, m_width, m_height, RGBBLACK); //initial black background
@@ -861,6 +865,7 @@ void CRmtView::OnInitialUpdate()
 	g_gfx_dc = &m_gfx_dc;
 	g_hwnd = AfxGetApp()->GetMainWnd()->m_hWnd;
 	g_viewhwnd = this->m_hWnd;
+	if (m_pen1) delete m_pen1;
 	m_pen1 = new CPen(PS_SOLID, 1, RGBLINES);	
 	m_penorig = g_mem_dc->SelectObject(m_pen1);
 	m_mem_dc.FillSolidRect(0, 0, m_width, m_height, RGBBLACK); //initial black background

--- a/cpp_src/RmtView.h
+++ b/cpp_src/RmtView.h
@@ -11,6 +11,7 @@
 
 #include "r_music.h"
 #include "RmtMidi.h"
+#include "RmtDoc.h"
 
 extern CDC* g_mem_dc;
 
@@ -125,20 +126,9 @@ extern int g_midi_volumeoffset;
 extern BOOL g_midi_noteoff;
 
 extern void SetStatusBarText(const char* text);
-extern void TextXY(char *txt,int x,int y,int c=0);
-
-extern void Memory_Clear();
-extern int Atari_LoadRMTRoutines();
-extern int Atari_InitRMTRoutine();
-extern void Get_Driver_Version();	
-
-extern char CharH4(unsigned char b);
-extern char CharL4(unsigned char b);
 
 extern char NoteKey(int vk);
 extern char Numblock09Key(int vk);
-
-extern unsigned char g_atarimem[65536];
 
 extern CString g_prgpath;
 extern CString g_lastloadpath_songs;
@@ -146,9 +136,6 @@ extern CString g_lastloadpath_instruments;
 extern CString g_lastloadpath_tracks;
 
 extern CTrackClipboard g_trackcl;
-
-extern int Atari6502_Init();
-extern void Atari6502_DeInit();
 
 extern void SetChannelOnOff(int ch,int onoff);
 extern void SetChannelSolo(int ch);

--- a/cpp_src/Tuning.cpp
+++ b/cpp_src/Tuning.cpp
@@ -82,6 +82,504 @@ bool IS_GRITTY_DIST_C = 0;		//Distortion C, neither MOD3 nor MOD5 AUDF
 bool IS_UNSTABLE_DIST_C = 0;	//Distortion C, MOD5 AUDF and not MOD3 AUDF
 bool IS_METALLIC_POLY9 = 0;		//AUDCTL 0x80, Distortion 0 and 8, MOD7 AUDF
 
+//Thomas Young 1799's Well Temperament no.1
+const double YOUNG1[13] =
+{
+	1,
+	1.055709,
+	1.119770,
+	1.187690,
+	1.253887,
+	1.334739,
+	1.407637,
+	1.496513,
+	1.583581,
+	1.675715,
+	1.781546,
+	1.878851,
+	2
+};
+
+//Thomas Young 1799's Well Temperament no.2 
+const double YOUNG2[13] =
+{
+	1,
+	1.055880,
+	1.119929,
+	1.187865,
+	1.254242,
+	1.334839,
+	1.407840,
+	1.496616,
+	1.583819,
+	1.676105,
+	1.781797,
+	1.879240,
+	2
+};
+
+//Thomas Young 1807's Well Temperament
+const double YOUNG3[13] =
+{
+	1,
+	1.053497,
+	1.119929,
+	1.185185,
+	1.254242,
+	1.333333,
+	1.404663,
+	1.496616,
+	1.580246,
+	1.676105,
+	1.777777,
+	1.877119,
+	2
+};
+
+//Andreas Werckmeister's temperament III (the most famous one, 1681)
+const double WERCK3[13] =
+{
+	1,
+	1.053497,
+	1.117403,
+	1.185185,
+	1.252827,
+	1.333333,
+	1.404663,
+	1.494927,
+	1.580246,
+	1.670436,
+	1.777777,
+	1.879240,
+	2
+};
+
+//Tempérament Égal à Quintes Justes 
+const double QUINTE[13] =
+{
+	1,
+	1.059634,
+	1.122824,
+	1.189782,
+	1.260734,
+	1.335916,
+	1.415582,
+	1.5,
+	1.589451,
+	1.684236,
+	1.784674,
+	1.891101,
+	2.003875
+};
+
+//d'Alembert and Rousseau tempérament ordinaire (1752/1767)
+const double TEMPORD[13] =
+{
+	1,
+	1.051120,
+	1.118034,
+	1.181176,
+	1.250000,
+	1.331828,
+	1.403077,
+	1.495348,
+	1.574901,
+	1.671850,
+	1.773766,
+	1.872883,
+	2
+};
+
+//Aron - Neidhardt equal beating well temperament
+const double ARONIED[13] =
+{
+	1,
+	1.053497,
+	1.118144,
+	1.185185,
+	1.250031,
+	1.333333,
+	1.404663,
+	1.496112,
+	1.580246,
+	1.672002,
+	1.777777,
+	1.872885,
+	2
+};
+
+//Atom Schisma Scale
+const double ATOMSCH[13] =
+{
+	1,
+	1.059459,
+	1.122463,
+	1.189204,
+	1.259924,
+	1.334838,
+	1.414207,
+	1.498308,
+	1.587396,
+	1.681796,
+	1.781794,
+	1.887755,
+	2
+};
+
+//12 - tET approximation with minimal order 17 beats
+const double APPRX12[13] =
+{
+	1,
+	1.058823,
+	1.125000,
+	1.187500,
+	1.250000,
+	1.333333,
+	1.416666,
+	1.500000,
+	1.588235,
+	1.666666,
+	1.777777,
+	1.888888,
+	2
+};
+
+//Paul Bailey's modern well temperament (2002)
+const double BAILEY1[13] =
+{
+	1,
+	1.054892,
+	1.119671,
+	1.186774,
+	1.254242,
+	1.335183,
+	1.406531,
+	1.498302,
+	1.582329,
+	1.676250,
+	1.780202,
+	1.881407,
+	2
+};
+
+//John Barnes' temperament (1977) made after analysis of Wohltemperierte Klavier, 1/6 P
+const double BARNES1[13] =
+{
+	1,
+	1.055880,
+	1.119929,
+	1.187865,
+	1.254242,
+	1.336348,
+	1.407840,
+	1.496616,
+	1.583819,
+	1.676105,
+	1.781797,
+	1.881364,
+	2
+};
+
+//Bethisy temperament ordinaire, see Pierre - Yves Asselin : Musique et temperament
+const double BETHISY[13] =
+{
+	1,
+	1.051418,
+	1.118034,
+	1.181509,
+	1.250000,
+	1.331953,
+	1.403475,
+	1.495348,
+	1.575346,
+	1.671850,
+	1.774101,
+	1.872884,
+	2,
+};
+
+//Big Gulp
+const double BIGGULP[13] =
+{
+	1,
+	1.031250,
+	1.125000,
+	1.166666,
+	1.250000,
+	1.312500,
+	1.375000,
+	1.500000,
+	1.546875,
+	1.687500,
+	1.750000,
+	1.875000,
+	2
+};
+
+//12 - tone scale by Bohlen generated from the 4:7 : 10 triad, Acustica 39 / 2, 1978
+const double BOHLEN12[13] =
+{
+	1,
+	1.100000,
+	1.200000,
+	1.304347,
+	1.428571,
+	1.571428,
+	1.750000,
+	1.909090,
+	2.100000,
+	2.300000,
+	2.500000,
+	2.750000,
+	3
+};
+
+//This scale may also be called the "Wedding Cake"
+const double WEDDING[13] =
+{
+	1,
+	1.125000,
+	1.171875,
+	1.250000,
+	1.333333,
+	1.406250,
+	1.500000,
+	1.562500,
+	1.666666,
+	1.687500,
+	1.777777,
+	1.875000,
+	2
+};
+
+//Upside - Down Wedding Cake(divorce cake)
+const double DIVORCE[13] =
+{
+	1,
+	1.066666,
+	1.125000,
+	1.200000,
+	1.280000,
+	1.333333,
+	1.500000,
+	1.600000,
+	1.687500,
+	1.777777,
+	1.800000,
+	1.920000,
+	2
+};
+
+//12 - tone Pythagorean scale
+const double PYTHAG1[13] =
+{
+	1,
+	1.067871,
+	1.125000,
+	1.185185,
+	1.265625,
+	1.333333,
+	1.423828,
+	1.500000,
+	1.601806,
+	1.687500,
+	1.777777,
+	1.898437,
+	2
+};
+
+//Robert Schneider, scale of log(4) ..log(16), 1 / 1 = 264Hz
+const double LOGSCALE[13] =
+{
+	1,
+	1.160964,
+	1.292481,
+	1.403677,
+	1.500000,
+	1.584962,
+	1.660964,
+	1.729715,
+	1.792481,
+	1.850219,
+	1.903677,
+	1.953445,
+	2
+};
+
+//Zarlino temperament extraordinaire, 1024 - tET mapping
+const double ZARLINO1[13] =
+{
+	1,
+	1.041450,
+	1.116652,
+	1.180385,
+	1.247756,
+	1.337855,
+	1.393309,
+	1.494930,
+	1.567469,
+	1.669316,
+	1.777781,
+	1.865308,
+	2
+};
+
+//Fokker's 7-limit 12-tone just scale
+const double FOKKER7[13] =
+{
+	1,
+	1.071428,
+	1.125000,
+	1.166666,
+	1.250000,
+	1.333333,
+	1.406250,
+	1.500000,
+	1.607142,
+	1.666666,
+	1.750000,
+	1.875000,
+	2
+};
+
+//Bach temperament, a'=400 Hz
+const double BACH400[13] =
+{
+	1,
+	1.052192,
+	1.118997,
+	1.183716,
+	1.250521,
+	1.334029,
+	1.402922,
+	1.498956,
+	1.578288,
+	1.670146,
+	1.776618,
+	1.874739,
+	2
+};
+
+//Vallotti& Young scale(Vallotti version) also known as Tartini - Vallotti(1754)
+const double VALYOUNG[13] =
+{
+	1,
+	1.055880,
+	1.119929,
+	1.187865,
+	1.254242,
+	1.336348,
+	1.407840,
+	1.496616,
+	1.583819,
+	1.676105,
+	1.781797,
+	1.877119,
+	2
+};
+
+//Vallotti - Young and Werckmeister III, 10 cents 5 - limit lesfip scale
+const double VALYOWER[13] =
+{
+	1,
+	1.051637,
+	1.117298,
+	1.187060,
+	1.248356,
+	1.336846,
+	1.399836,
+	1.495457,
+	1.580099,
+	1.669531,
+	1.783574,
+	1.867613,
+	2
+};
+
+
+///!!!\\\ Testing some non-12 octaves scales here
+
+//Optimally consonant major pentatonic, John deLaubenfels(2001)
+const double PENTAOPT[6] =
+{
+	1,
+	1.118042,
+	1.250019,
+	1.496879,
+	1.670166,
+	2
+};
+
+//Ancient Greek Aeolic, also tritriadic scale of the 54:64 : 81 triad
+const double AEOLIC[8] =
+{
+	1,
+	1.125000,
+	1.185185,
+	1.333333,
+	1.500000,
+	1.580246,
+	1.777777,
+	2
+};
+
+//African Bapare xylophone(idiophone; loose log)
+const double XYLO1[11] =
+{
+	1,
+	1.076737,
+	1.200942,
+	1.336382,
+	1.497441,
+	1.670175,
+	1.932988,
+	2.174725,
+	2.285484,
+	2.525670,
+	2.738400
+};
+
+//African Yaswa xylophones(idiophone; calbash resonators with membrane)
+const double XYLO2[11] =
+{
+	1,
+	1.128312,
+	1.271619,
+	1.486239,
+	1.707240,
+	1.936341,
+	2.015074,
+	2.215296,
+	2.419988,
+	2.871225,
+	3.220980
+};
+
+//19-EDO generated using Scale Workshop
+const double NINTENDO[20] =
+{
+	1,
+	1.037155,
+	1.075690,
+	1.115657,
+	1.157110,
+	1.200102,
+	1.244692,
+	1.290939,
+	1.338904,
+	1.388651,
+	1.440246,
+	1.493759,
+	1.549259,
+	1.606822,
+	1.666524,
+	1.728443,
+	1.792664,
+	1.859270,
+	1.928352,
+	2
+};
+
 //Parts of this code was rewritten for POKEY Frequencies Calculator, then backported to RMT 1.31+
 void real_freq()
 {

--- a/cpp_src/Tuning.h
+++ b/cpp_src/Tuning.h
@@ -24,38 +24,6 @@ extern double g_basetuning;
 extern int g_basenote;
 extern int g_temperament;
 
-//preset temperament/ratios
-extern const double YOUNG1[13];
-extern const double YOUNG2[13];
-extern const double YOUNG3[13];
-extern const double WERCK3[13];
-extern const double QUINTE[13];
-extern const double TEMPORD[13];
-extern const double ARONIED[13];
-extern const double ATOMSCH[13];
-extern const double APPRX12[13];
-extern const double BAILEY1[13];
-extern const double BARNES1[13];
-extern const double BETHISY[13];
-extern const double BIGGULP[13];
-extern const double BOHLEN12[13];
-extern const double WEDDING[13];
-extern const double DIVORCE[13];
-extern const double PYTHAG1[13];
-extern const double LOGSCALE[13];
-extern const double ZARLINO1[13];
-extern const double FOKKER7[13];
-extern const double BACH400[13];
-extern const double VALYOUNG[13];
-extern const double VALYOWER[13];
-
-///!!!\\\ Testing some non-12 octaves scales here
-extern const double PENTAOPT[6];
-extern const double AEOLIC[8];
-extern const double XYLO1[11];
-extern const double XYLO2[11];
-extern const double NINTENDO[20];
-
 //ratio used for each note => NOTE_L / NOTE_R, must be treated as doubles!!!
 extern double g_UNISON;
 extern double g_MIN_2ND;

--- a/cpp_src/XPokey.cpp
+++ b/cpp_src/XPokey.cpp
@@ -4,6 +4,7 @@
 // TODO: fix apokeysnd support, and backport sapokey changes to alternative plugins
 
 #include "stdafx.h"
+#include "Rmt.h"
 #include "XPokey.h"
 #include "RmtView.h"
 #include "Atari6502.h"
@@ -58,10 +59,14 @@ int tracks = g_tracks4_8;
 static LPDIRECTSOUND          g_lpds;
 static LPDIRECTSOUNDBUFFER    g_lpdsbPrimary;
 
+int loops = 0;
+
 CXPokey::CXPokey()
 {
-	m_rendersound=0;
-	m_SoundBuffer=NULL;
+	m_rendersound = 0;
+	m_pokey_dll = NULL;
+	m_SoundBuffer = NULL;
+
 }
 
 CXPokey::~CXPokey()

--- a/cpp_src/XPokey.h
+++ b/cpp_src/XPokey.h
@@ -16,22 +16,8 @@
 /////////////////////////////////////////////////////////////////////////////
 // CMy2PokeysDlg dialog
 
-extern HWND g_hwnd;
-extern int g_tracks4_8;
-extern BOOL g_nohwsoundbuffer;
-extern BOOL g_ntsc;
-
 //hacked up, this should be restructured into a proper class and done in a cleaner way
-extern unsigned char SAPRSTREAM[0xFFFFFF];
-extern int SAPRDUMP;
-extern int framecount;
-int loops = 0;
-
-extern BOOL volatile g_rmtroutine;
-extern void Atari_PlayRMT();
-
-extern unsigned char g_atarimem[65536];
-extern void TextXY(char *txt,int x,int y,int c);
+extern int loops;
 
 #define CHANNELS		2
 #define BITRESOLUTION	8
@@ -50,10 +36,6 @@ extern void TextXY(char *txt,int x,int y,int c);
 
 #define CYCLESPERSCREEN ((float)CYCLESPERSECOND/FRAMERATE)
 #define CYCLESPERSAMPLE	((float)CYCLESPERSECOND/44100)
-
-extern CString g_aboutpokey;
-
-extern int GetChannelOnOff(int ch);
 
 class CXPokey
 {

--- a/cpp_src/global.h
+++ b/cpp_src/global.h
@@ -7,1093 +7,227 @@
 #ifndef RMT_GLOBAL_
 #define RMT_GLOBAL_
 
-unsigned char g_atarimem[65536];
-char g_debugmem[65536];	//debug display of g_atarimem bytes directly, slow and terrible, do not use unless there is a purpose for it 
+#include <iostream>
+#include <fstream>
 
-unsigned char SAPRSTREAM[0xFFFFFF];	//SAP-R Dumper memory, TODO: assign memory dynamically instead, however this doesn't seem to harm anything for now
+#define TEXT_COLOR_WHITE 0
+#define TEXT_COLOR_GRAY 1
+#define TEXT_COLOR_YELLOW 2
+#define TEXT_COLOR_INVERSE_BLUE 3
+#define TEXT_COLOR_INVERSE_WHITE 4
+#define TEXT_COLOR_CYAN 5
+#define TEXT_COLOR_RED 6
+#define TEXT_COLOR_INVERSE_RED 9
+#define TEXT_COLOR_EXTRA 10
+#define TEXT_COLOR_BLUE 13
+#define TEXT_COLOR_LIGHT_GRAY 14
 
-int SAPRDUMP = 0;		//0, the SAPR dumper is disabled; 1, output is currently recorded to memory; 2, recording is finished and will be written to sap file; 3, flag engage the SAPR dumper
-int framecount = 0;		//SAPR dumper frame counter used for calculations and memory allignment with bytes 
 
-char CharH4(unsigned char b) { BYTE i=b>>4; return ((BYTE)i+((i<10)? 48:55)); };
-char CharL4(unsigned char b) { BYTE i=b&0x0f; return ((BYTE)i + ((i<10)? 48:55)); };
-int Hexstr(char* txt,int len)
-{
-	int r=0;
-	char a;
-	int i;
-	for (i = 0; (a = txt[i]) && i < len; i++)
-	{
-		if (a>='0' && a<='9') 
-			r = (r<<4) + (a-'0');
-		else
-		if (a>='A' && a<='F') 
-			r = (r<<4) + (a-'A'+10);
-		else
-		{
-			if (i==0) r=-1; //nothing
-			return r;
-		}
-	}
-	if (i==0) r=-1; //nothing
-	return r;
-}
-BOOL NextSegment(ifstream& in)
-{
-	char b;
-	while(!in.eof())
-	{
-		in.read((char*)&b,1);
-		if (b=='[') return 1;	//end of segment (beginning of something else)
-	}
-	return 0;
-}
-void Trimstr(char* txt)
-{
-	char a;
-	for(int i=0; (a=txt[i]); i++)
-	{
-		if (a==13 || a==10)
-		{
-			txt[i]=0;
-			return;
-		}
-	}
-}
+#define COLOR_SELECTED			TEXT_COLOR_INVERSE_RED	//highlight colour
+#define COLOR_SELECTED_PROVE	TEXT_COLOR_INVERSE_BLUE	//highlight colour in PROVE mode
 
-BOOL g_closeapplication=0;
-CDC* g_mem_dc=NULL;
-CDC* g_gfx_dc=NULL;
+#define TEXT_MINI_COLOR_GRAY 0
+#define TEXT_MINI_COLOR_BLUE 1
+#define TEXT_MINI_COLOR_WHITE 2
+#define TEXT_MINI_COLOR_YELLOW 3
 
-int g_width = 0;
-int g_height = 0;
-int g_tracklines = 8;
-int g_scaling_percentage = 100;
+extern unsigned char g_atarimem[65536];
+extern char g_debugmem[65536];	//debug display of g_atarimem bytes directly, slow and terrible, do not use unless there is a purpose for it 
+
+extern unsigned char SAPRSTREAM[0xFFFFFF];	//SAP-R Dumper memory, TODO: assign memory dynamically instead, however this doesn't seem to harm anything for now
+
+extern int SAPRDUMP;		//0, the SAPR dumper is disabled; 1, output is currently recorded to memory; 2, recording is finished and will be written to sap file; 3, flag engage the SAPR dumper
+extern int framecount;		//SAPR dumper frame counter used for calculations and memory allignment with bytes 
+
+extern int Hexstr(char* txt, int len);
+
+extern BOOL g_closeapplication;
+extern CDC* g_mem_dc;
+extern CDC* g_gfx_dc;
+
+extern int g_width;
+extern int g_height;
+extern int g_tracklines;
+extern int g_scaling_percentage;
 
 //best known compromise for both regions, they produce identical tables
-double g_basetuning = (g_ntsc) ? 444.895778867913 : 440.83751645933;
-int g_basenote = 3;	//3 = A-
+extern double g_basetuning;
+extern int g_basenote;
 
 //ratio used for each note => NOTE_L / NOTE_R, must be treated as doubles!!!
-double g_UNISON = 1;
-double g_MIN_2ND = 1;
-double g_MAJ_2ND = 1;
-double g_MIN_3RD = 1;
-double g_MAJ_3RD = 1;
-double g_PERF_4TH = 1;
-double g_TRITONE = 1;
-double g_PERF_5TH = 1;
-double g_MIN_6TH = 1;
-double g_MAJ_6TH = 1;
-double g_MIN_7TH = 1;
-double g_MAJ_7TH = 1;
-double g_OCTAVE = 2;
+extern double g_UNISON;
+extern double g_MIN_2ND;
+extern double g_MAJ_2ND;
+extern double g_MIN_3RD;
+extern double g_MAJ_3RD;
+extern double g_PERF_4TH;
+extern double g_TRITONE;
+extern double g_PERF_5TH;
+extern double g_MIN_6TH;
+extern double g_MAJ_6TH;
+extern double g_MIN_7TH;
+extern double g_MAJ_7TH;
+extern double g_OCTAVE;
 
 //ratio left
-int g_UNISON_L = 1;
-int g_MIN_2ND_L = 40;
-int g_MAJ_2ND_L = 10;
-int g_MIN_3RD_L = 20;
-int g_MAJ_3RD_L = 5;
-int g_PERF_4TH_L = 4;
-int g_TRITONE_L = 60;
-int g_PERF_5TH_L = 3;
-int g_MIN_6TH_L = 30;
-int g_MAJ_6TH_L = 5;
-int g_MIN_7TH_L = 30;
-int g_MAJ_7TH_L = 15;
-int g_OCTAVE_L = 2;
+extern int g_UNISON_L;
+extern int g_MIN_2ND_L;
+extern int g_MAJ_2ND_L;
+extern int g_MIN_3RD_L;
+extern int g_MAJ_3RD_L;
+extern int g_PERF_4TH_L;
+extern int g_TRITONE_L;
+extern int g_PERF_5TH_L;
+extern int g_MIN_6TH_L;
+extern int g_MAJ_6TH_L;
+extern int g_MIN_7TH_L;
+extern int g_MAJ_7TH_L;
+extern int g_OCTAVE_L;
 
 //ratio right
-int g_UNISON_R = 1;
-int g_MIN_2ND_R = 38;
-int g_MAJ_2ND_R = 9;
-int g_MIN_3RD_R = 17;
-int g_MAJ_3RD_R = 4;
-int g_PERF_4TH_R = 3;
-int g_TRITONE_R = 43;
-int g_PERF_5TH_R = 2;
-int g_MIN_6TH_R = 19;
-int g_MAJ_6TH_R = 3;
-int g_MIN_7TH_R = 17;
-int g_MAJ_7TH_R = 8;
-int g_OCTAVE_R = 1;
+extern int g_UNISON_R;
+extern int g_MIN_2ND_R;
+extern int g_MAJ_2ND_R;
+extern int g_MIN_3RD_R;
+extern int g_MAJ_3RD_R;
+extern int g_PERF_4TH_R;
+extern int g_TRITONE_R;
+extern int g_PERF_5TH_R;
+extern int g_MIN_6TH_R;
+extern int g_MAJ_6TH_R;
+extern int g_MIN_7TH_R;
+extern int g_MAJ_7TH_R;
+extern int g_OCTAVE_R;
 
 //each preset is assigned to a number. 0 means no Temperament, any value that is not assigned defaults to custom
-int g_temperament = 0;
+extern int g_temperament;
 
-//Thomas Young 1799's Well Temperament no.1
-const double YOUNG1[13] =
-{
-	1,
-	1.055709,
-	1.119770,
-	1.187690,
-	1.253887,
-	1.334739,
-	1.407637,
-	1.496513,
-	1.583581,
-	1.675715,
-	1.781546,
-	1.878851,
-	2
-};
+extern HWND g_hwnd;
+extern HWND g_viewhwnd;
 
-//Thomas Young 1799's Well Temperament no.2 
-const double YOUNG2[13] =
-{
-	1,
-	1.055880,
-	1.119929,
-	1.187865,
-	1.254242,
-	1.334839,
-	1.407840,
-	1.496616,
-	1.583819,
-	1.676105,
-	1.781797,
-	1.879240,
-	2
-};
+extern HINSTANCE g_c6502_dll;
+extern BOOL volatile g_is6502;
+extern CString g_aboutpokey;
+extern CString g_about6502;
+extern CString g_driverversion;
 
-//Thomas Young 1807's Well Temperament
-const double YOUNG3[13] =
-{
-	1,
-	1.053497,
-	1.119929,
-	1.185185,
-	1.254242,
-	1.333333,
-	1.404663,
-	1.496616,
-	1.580246,
-	1.676105,
-	1.777777,
-	1.877119,
-	2
-};
+extern BOOL g_changes;	//have there been any changes in the module?
 
-//Andreas Werckmeister's temperament III (the most famous one, 1681)
-const double WERCK3[13] =
-{
-	1,
-	1.053497,
-	1.117403,
-	1.185185,
-	1.252827,
-	1.333333,
-	1.404663,
-	1.494927,
-	1.580246,
-	1.670436,
-	1.777777,
-	1.879240,
-	2
-};
+extern int g_focus;
+extern int g_shiftkey;
+extern int g_controlkey;
+extern int g_altkey;	//unfinished implementation, doesn't work yet for some reason
 
-//Tempérament Égal à Quintes Justes 
-const double QUINTE[13] =
-{
-	1,
-	1.059634,
-	1.122824,
-	1.189782,
-	1.260734,
-	1.335916,
-	1.415582,
-	1.5,
-	1.589451,
-	1.684236,
-	1.784674,
-	1.891101,
-	2.003875
-};
+extern int g_tracks4_8;
+extern BOOL volatile g_screenupdate;
+extern BOOL volatile g_invalidatebytimer;
+extern int volatile g_screena;
+extern int volatile g_screenwait;
+extern BOOL volatile g_rmtroutine;
+extern BOOL volatile g_timerroutineprocessed;
 
-//d'Alembert and Rousseau tempérament ordinaire (1752/1767)
-const double TEMPORD[13] =
-{
-	1,
-	1.051120,
-	1.118034,
-	1.181176,
-	1.250000,
-	1.331828,
-	1.403077,
-	1.495348,
-	1.574901,
-	1.671850,
-	1.773766,
-	1.872883,
-	2
-};
+extern int volatile g_prove;			//test notes without editing (0 = off, 1 = mono, 2 = stereo)
+extern int volatile g_respectvolume;	//does not change the volume if it is already there
 
-//Aron - Neidhardt equal beating well temperament
-const double ARONIED[13] =
-{
-	1,
-	1.053497,
-	1.118144,
-	1.185185,
-	1.250031,
-	1.333333,
-	1.404663,
-	1.496112,
-	1.580246,
-	1.672002,
-	1.777777,
-	1.872885,
-	2
-};
+extern WORD g_rmtstripped_adr_module;	//address for export RMT stripped file
+extern BOOL g_rmtstripped_sfx;			//sfx offshoot RMT stripped file
+extern BOOL g_rmtstripped_gvf;			//gvs GlobalVolumeFade for feat
+extern BOOL g_rmtstripped_nos;			//nos NoStartingSongline for feat
 
-//Atom Schisma Scale
-const double ATOMSCH[13] =
-{
-	1,
-	1.059459,
-	1.122463, 
-	1.189204,
-	1.259924,
-	1.334838,
-	1.414207,
-	1.498308,
-	1.587396,
-	1.681796,
-	1.781794,
-	1.887755,
-	2
-};
+extern CString g_rmtmsxtext;
+extern CString g_expasmlabelprefix;	//label prefix for export ASM simple notation
 
-//12 - tET approximation with minimal order 17 beats
-const double APPRX12[13] =
-{
-	1,
-	1.058823,
-	1.125000,
-	1.187500,
-	1.250000,
-	1.333333,
-	1.416666,
-	1.500000,
-	1.588235,
-	1.666666,
-	1.777777,
-	1.888888,
-	2
-};
+extern int g_activepart;			//0 info, 1 edittracks, 2 editinstruments, 3 song
+extern int g_active_ti;			//1 tracks, 2 instrs
 
-//Paul Bailey's modern well temperament (2002)
-const double BAILEY1[13] =
-{
-	1,
-	1.054892,
-	1.119671,
-	1.186774,
-	1.254242,
-	1.335183,
-	1.406531,
-	1.498302,
-	1.582329,
-	1.676250,
-	1.780202,
-	1.881407,
-	2
-};
+extern BOOL is_editing_instr;		//0 no, 1 instrument name is edited
+extern BOOL is_editing_infos;		//0 no, 1 song name is edited
 
-//John Barnes' temperament (1977) made after analysis of Wohltemperierte Klavier, 1/6 P
-const double BARNES1[13] =
-{
-	1,
-	1.055880,
-	1.119929,
-	1.187865,
-	1.254242,
-	1.336348,
-	1.407840,
-	1.496616,
-	1.583819,
-	1.676105,
-	1.781797,
-	1.881364,
-	2
-};
+extern int g_tracklinehighlight;	//line highlighted every x lines
+extern BOOL g_tracklinealtnumbering; //alternative way of line numbering in tracks
+extern int g_linesafter;			//number of lines to scroll after inserting a note (initializes in CSong :: Clear)
+extern BOOL g_ntsc;				//NTSC (60Hz)
+extern BOOL g_nohwsoundbuffer;	//Don't use hardware soundbuffer
+extern int g_cursoractview;		//default position, line 0
 
-//Bethisy temperament ordinaire, see Pierre - Yves Asselin : Musique et temperament
-const double BETHISY[13] =
-{
-	1,
-	1.051418,
-	1.118034,
-	1.181509,
-	1.250000,
-	1.331953,
-	1.403475,
-	1.495348,
-	1.575346,
-	1.671850,
-	1.774101,
-	1.872884,
-	2,
-};
+extern BOOL g_displayflatnotes;	//flats instead of sharps
+extern BOOL g_usegermannotation;	//H notes instead of B
 
-//Big Gulp
-const double BIGGULP[13] =
-{
-	1,
-	1.031250,
-	1.125000,
-	1.166666,
-	1.250000,
-	1.312500,
-	1.375000,
-	1.500000,
-	1.546875,
-	1.687500,
-	1.750000,
-	1.875000,
-	2
-};
+extern int g_channelon[SONGTRACKS];
+extern int g_rmtinstr[SONGTRACKS];
 
-//12 - tone scale by Bohlen generated from the 4:7 : 10 triad, Acustica 39 / 2, 1978
-const double BOHLEN12[13] =
-{
-	1,
-	1.100000,
-	1.200000,
-	1.304347,
-	1.428571,
-	1.571428,
-	1.750000,
-	1.909090,
-	2.100000,
-	2.300000,
-	2.500000,
-	2.750000,
-	3
-};
+extern BOOL g_viewmaintoolbar;		//1 yes, 0 no
+extern BOOL g_viewblocktoolbar;		//1 yes, 0 no
+extern BOOL g_viewstatusbar;		//1 yes, 0 no
+extern BOOL g_viewplaytimecounter;	//1 yes, 0 no
+extern BOOL g_viewanalyzer;			//1 yes, 0 no
+extern BOOL g_viewpokeyregs;		//1 yes, 0 no
+extern BOOL g_viewinstractivehelp;	//1 yes, 0 no
 
-//This scale may also be called the "Wedding Cake"
-const double WEDDING[13] =
-{
-	1,
-	1.125000,
-	1.171875,
-	1.250000,
-	1.333333,
-	1.406250,
-	1.500000,
-	1.562500,
-	1.666666,
-	1.687500,
-	1.777777,
-	1.875000,
-	2
-};
+extern long g_playtime;				//1 yes, 0 no
 
-//Upside - Down Wedding Cake(divorce cake)
-const double DIVORCE[13] =
-{
-	1,
-	1.066666,
-	1.125000,
-	1.200000,
-	1.280000,
-	1.333333,
-	1.500000,
-	1.600000,
-	1.687500,
-	1.777777,
-	1.800000,
-	1.920000,
-	2
-};
+extern UINT g_mousebutt;			//mouse button
 
-//12 - tone Pythagorean scale
-const double PYTHAG1[13] =
-{
-	1,
-	1.067871,
-	1.125000,
-	1.185185,
-	1.265625,
-	1.333333,
-	1.423828,
-	1.500000,
-	1.601806,
-	1.687500,
-	1.777777,
-	1.898437,
-	2
-};
+extern CTrackClipboard g_trackcl;
 
-//Robert Schneider, scale of log(4) ..log(16), 1 / 1 = 264Hz
-const double LOGSCALE[13] =
-{
-	1,
-	1.160964,
-	1.292481,
-	1.403677,
-	1.500000,
-	1.584962,
-	1.660964,
-	1.729715,
-	1.792481,
-	1.850219,
-	1.903677,
-	1.953445,
-	2
-};
+extern CString g_prgpath;					//path to the directory from which the program was started (including a slash at the end)
+extern CString g_lastloadpath_songs;		//the path of the last song loaded
+extern CString g_lastloadpath_instruments; //the path of the last instrument loaded
+extern CString g_lastloadpath_tracks;		//the path of the last track loaded
 
-//Zarlino temperament extraordinaire, 1024 - tET mapping
-const double ZARLINO1[13] =
-{
-	1,
-	1.041450,
-	1.116652,
-	1.180385,
-	1.247756,
-	1.337855,
-	1.393309,
-	1.494930,
-	1.567469,
-	1.669316,
-	1.777781,
-	1.865308,
-	2
-};
+extern CString g_path_songs;		//default path for songs
+extern CString g_path_instruments;	//default path for instruments
+extern CString g_path_tracks;		//default path for tracks
 
-//Fokker's 7-limit 12-tone just scale
-const double FOKKER7[13] =
-{
-	1,
-	1.071428,
-	1.125000,
-	1.166666, 
-	1.250000,
-	1.333333, 
-	1.406250,
-	1.500000,
-	1.607142, 
-	1.666666,
-	1.750000, 
-	1.875000, 
-	2
-};
+extern int g_keyboard_layout;			//1 yes, 0 no, not be useful anymore... should be deleted
+extern BOOL g_keyboard_swapenter;		//1 yes, 0 no, probably not needed anymore but will be kept for now
+extern BOOL g_keyboard_playautofollow;	//1 yes, 0 no
+extern BOOL g_keyboard_updowncontinue;	//1 yes, 0 no
+extern BOOL g_keyboard_rememberoctavesandvolumes;	//1 yes, 0 no
+extern BOOL g_keyboard_escresetatarisound;	//1 yes, 0 no
+extern BOOL g_keyboard_askwhencontrol_s;	//1 yes, 0 no
 
-//Bach temperament, a'=400 Hz
-const double BACH400[13] =
-{
-	1,
-	1.052192,
-	1.118997,
-	1.183716,
-	1.250521,
-	1.334029,
-	1.402922,
-	1.498956,
-	1.578288,
-	1.670146,
-	1.776618,
-	1.874739,
-	2
-};
+extern int g_midi_notech[16];			//last recorded notes on each MIDI channel
+extern int g_midi_voluch[16];			//note volume on individual MIDI channels
+extern int g_midi_instch[16];			//last set instrument numbers on individual MIDI channels
 
-//Vallotti& Young scale(Vallotti version) also known as Tartini - Vallotti(1754)
-const double VALYOUNG[13] =
-{
-	1,
-	1.055880,
-	1.119929,
-	1.187865,
-	1.254242,
-	1.336348,
-	1.407840,
-	1.496616,
-	1.583819,
-	1.676105,
-	1.781797,
-	1.877119,
-	2
-};
-
-//Vallotti - Young and Werckmeister III, 10 cents 5 - limit lesfip scale
-const double VALYOWER[13] =
-{
-	1,
-	1.051637,
-	1.117298,
-	1.187060,
-	1.248356,
-	1.336846,
-	1.399836,
-	1.495457,
-	1.580099,
-	1.669531,
-	1.783574,
-	1.867613,
-	2
-};
-
-
-///!!!\\\ Testing some non-12 octaves scales here
-
-//Optimally consonant major pentatonic, John deLaubenfels(2001)
-const double PENTAOPT[6] =
-{
-	1,
-	1.118042,
-	1.250019,
-	1.496879,
-	1.670166,
-	2
-};
-
-//Ancient Greek Aeolic, also tritriadic scale of the 54:64 : 81 triad
-const double AEOLIC[8] =
-{
-	1,
-	1.125000,
-	1.185185,
-	1.333333,
-	1.500000,
-	1.580246,
-	1.777777,
-	2
-};
-
-//African Bapare xylophone(idiophone; loose log)
-const double XYLO1[11] =
-{
-	1,
-	1.076737,
-	1.200942,
-	1.336382,
-	1.497441,
-	1.670175,
-	1.932988,
-	2.174725,
-	2.285484,
-	2.525670,
-	2.738400
-};
-
-//African Yaswa xylophones(idiophone; calbash resonators with membrane)
-const double XYLO2[11] =
-{
-	1,
-	1.128312,
-	1.271619,
-	1.486239,
-	1.707240,
-	1.936341,
-	2.015074,
-	2.215296,
-	2.419988,
-	2.871225,
-	3.220980
-};
-
-//19-EDO generated using Scale Workshop
-const double NINTENDO[20] =
-{
-	1,
-	1.037155,
-	1.075690,
-	1.115657,
-	1.157110,
-	1.200102,
-	1.244692,
-	1.290939,
-	1.338904,
-	1.388651,
-	1.440246,
-	1.493759,
-	1.549259,
-	1.606822,
-	1.666524,
-	1.728443,
-	1.792664,
-	1.859270,
-	1.928352,
-	2
-};
-
-
-HWND g_hwnd=NULL;
-HWND g_viewhwnd=NULL;
-
-HINSTANCE g_c6502_dll;
-BOOL volatile g_is6502 = 0;
-CString g_aboutpokey;
-CString g_about6502;
-CString g_driverversion;
-
-BOOL g_changes=0;	//have there been any changes in the module?
-
-int g_focus;
-int g_shiftkey;
-int g_controlkey;
-int g_altkey;	//unfinished implementation, doesn't work yet for some reason
-
-int g_tracks4_8;
-BOOL volatile g_screenupdate=0;
-BOOL volatile g_invalidatebytimer=0;
-int volatile g_screena;
-int volatile g_screenwait;
-BOOL volatile g_rmtroutine;
-BOOL volatile g_timerroutineprocessed;
-
-int volatile g_prove;			//test notes without editing (0 = off, 1 = mono, 2 = stereo)
-int volatile g_respectvolume;	//does not change the volume if it is already there
-
-WORD g_rmtstripped_adr_module;	//address for export RMT stripped file
-BOOL g_rmtstripped_sfx;			//sfx offshoot RMT stripped file
-BOOL g_rmtstripped_gvf;			//gvs GlobalVolumeFade for feat
-BOOL g_rmtstripped_nos;			//nos NoStartingSongline for feat
-
-CString g_rmtmsxtext;
-CString g_expasmlabelprefix;	//label prefix for export ASM simple notation
-
-int g_activepart;			//0 info, 1 edittracks, 2 editinstruments, 3 song
-int g_active_ti;			//1 tracks, 2 instrs
-
-BOOL is_editing_instr;		//0 no, 1 instrument name is edited
-BOOL is_editing_infos;		//0 no, 1 song name is edited
-
-int g_tracklinehighlight=8;	//line highlighted every x lines
-BOOL g_tracklinealtnumbering=0; //alternative way of line numbering in tracks
-int g_linesafter;			//number of lines to scroll after inserting a note (initializes in CSong :: Clear)
-BOOL g_ntsc=0;				//NTSC (60Hz)
-BOOL g_nohwsoundbuffer=0;	//Don't use hardware soundbuffer
-int g_cursoractview=0;		//default position, line 0
-
-BOOL g_displayflatnotes = 0;	//flats instead of sharps
-BOOL g_usegermannotation = 0;	//H notes instead of B
-
-int g_channelon[SONGTRACKS];
-int g_rmtinstr[SONGTRACKS];
-
-BOOL g_viewmaintoolbar=1;		//1 yes, 0 no
-BOOL g_viewblocktoolbar=1;		//1 yes, 0 no
-BOOL g_viewstatusbar=1;			//1 yes, 0 no
-BOOL g_viewplaytimecounter=1;	//1 yes, 0 no
-BOOL g_viewanalyzer=1;			//1 yes, 0 no
-BOOL g_viewpokeyregs=1;			//1 yes, 0 no
-BOOL g_viewinstractivehelp=1;	//1 yes, 0 no
-
-long g_playtime=1;	//1 yes, 0 no
-
-UINT g_mousebutt=0;			//mouse button
-
-CTrackClipboard g_trackcl;
-
-CString g_prgpath;					//path to the directory from which the program was started (including a slash at the end)
-CString g_lastloadpath_songs;		//the path of the last song loaded
-CString g_lastloadpath_instruments; //the path of the last instrument loaded
-CString g_lastloadpath_tracks;		//the path of the last track loaded
-
-CString g_path_songs;		//default path for songs
-CString g_path_instruments;	//default path for instruments
-CString g_path_tracks;		//default path for tracks
-
-int g_keyboard_layout=0;	//1 yes, 0 no, not be useful anymore... should be deleted
-BOOL g_keyboard_swapenter=0;	//1 yes, 0 no, probably not needed anymore but will be kept for now
-BOOL g_keyboard_playautofollow=1;	//1 yes, 0 no
-BOOL g_keyboard_updowncontinue=1;	//1 yes, 0 no
-BOOL g_keyboard_rememberoctavesandvolumes=1;	//1 yes, 0 no
-BOOL g_keyboard_escresetatarisound=1;	//1 yes, 0 no
-BOOL g_keyboard_askwhencontrol_s=1;	//1 yes, 0 no
-
-int g_midi_notech[16];			//last recorded notes on each MIDI channel
-int g_midi_voluch[16];			//note volume on individual MIDI channels
-int g_midi_instch[16];			//last set instrument numbers on individual MIDI channels
-
-BOOL g_midi_tr=0;
-int g_midi_volumeoffset=1;	//starts from volume 1 by default
-BOOL g_midi_noteoff=0;		//by default, noteoff is turned off
-
-#define COLOR_SELECTED	9	//highlight colour
-#define COLOR_SELECTED_PROVE	3	//highlight colour in PROVE mode
+extern BOOL g_midi_tr;
+extern int g_midi_volumeoffset;	//starts from volume 1 by default
+extern BOOL g_midi_noteoff;		//by default, noteoff is turned off
 
 //----
 
-void TextXY(char* txt, int x, int y, int c)
-{
-	int sp = g_scaling_percentage;
-
-	char a;
-	c=c<<4;
-	for (int i = 0; a = (txt[i]); i++, x += 8)
-		if (a != 32) g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (16 * sp) / 100, g_gfx_dc, (a & 0x7f) << 3, c, 8, 16, SRCCOPY);
-}
-
-void TextXYSelN(char *txt,int n,int x,int y,int c=0)
-{
-	//the index character n will have a "select" color, the rest c
-	int sp = g_scaling_percentage;
-	char a;
-	c=c<<4;
-
-	int col = (g_prove) ? COLOR_SELECTED_PROVE : COLOR_SELECTED;
-
-	int i;
-	for (i = 0; a = (txt[i]); i++, x += 8)
-		g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (16 * sp) / 100, g_gfx_dc, (a & 0x7f) << 3, (i == n) ? col * 16 : c, 8, 16, SRCCOPY);
-	if (i == n) //the first character after the end of the string
-		g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (16 * sp) / 100, g_gfx_dc, 32 << 3, col * 16, 8, 16, SRCCOPY);
-}
-
-void TextXYCol(char *txt,int x,int y,char *col)
-{
-	int sp = g_scaling_percentage;
-	char a;
-	for (int i = 0; a = (txt[i]); i++, x += 8)
-		g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (16 * sp) / 100, g_gfx_dc, (a & 0x7f) << 3, col[i] << 4, 8, 16, SRCCOPY);
-}
-
-void TextDownXY(char *txt,int x,int y,int c=0)
-{
-	int sp = g_scaling_percentage;
-	char a;
-	c=c<<4;
-	for (int i = 0; a = (txt[i]); i++, y += 16)
-		g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (16 * sp) / 100, g_gfx_dc, (a & 0x7f) << 3, c, 8, 16, SRCCOPY);
-}
-
-void NumberMiniXY(BYTE num,int x,int y,int c=0)
-{
-	int sp = g_scaling_percentage;
-	c=112+(c<<3);
-	g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (8 * sp) / 100, g_gfx_dc, (num & 0xf0) >> 1, c, 8, 8, SRCCOPY);
-	g_mem_dc->StretchBlt(((x + 8) * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (8 * sp) / 100, g_gfx_dc, (num & 0x0f) << 3, c, 8, 8, SRCCOPY);
-}
-
-void TextMiniXY(char *txt,int x,int y,int c=0)
-{
-	int sp = g_scaling_percentage;
-	char a;
-	c=112+(c<<3);
-	for (int i = 0; a = (txt[i]); i++, x += 8)
-		if (a != 32) g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (8 * sp) / 100, g_gfx_dc, (a & 0x7f) << 3, c, 8, 8, SRCCOPY);
-}
-
-void IconMiniXY(int icon,int x,int y)
-{
-	int sp = g_scaling_percentage;
-	static int c=128-6;
-	if (icon >= 1 && icon <= 4) g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (32 * sp) / 100, (6 * sp) / 100, g_gfx_dc, (icon - 1) * 32, c, 32, 6, SRCCOPY);
-}
-
-void GetTracklineText(char *dest,int line)
-{
-	if (line<0 || line>0xff) { dest[0]=0; return; }
-	if (g_tracklinealtnumbering)
-	{
-		int a=line/g_tracklinehighlight;
-		if (a>=35) a=(a-35)%26+'a'-'9'+1;
-		int b=line%g_tracklinehighlight;
-		if (b>=35) b=(b-35)%26+'a'-'9'+1;
-		if (a<=8)
-			a='1'+a;
-		else
-			a='A'-9+a;
-		if (b<=8)
-			b='1'+b;
-		else
-			b='A'-9+b;
-		dest[0]=a;
-		dest[1]=b;
-		dest[2]=0;
-	}
-	else
-		sprintf(dest,"%02X",line);
-}
-
-void UpdateShiftControlKeys()
-{
-	g_shiftkey=(GetAsyncKeyState(VK_SHIFT)!=NULL);
-	g_controlkey=(GetAsyncKeyState(VK_CONTROL)!=NULL);
-	g_altkey=(GetAsyncKeyState(VK_MENU)!=NULL);
-}
-
-BOOL IsnotMovementVKey(int vk)
-{
-	//returns 1 if it is not a scroll key
-	return (vk!=VK_RIGHT && vk!=VK_LEFT && vk!=VK_UP && vk!=VK_DOWN && vk!=VK_TAB && vk!=13 && vk!=VK_HOME && vk!=VK_END && vk!=VK_PAGE_UP && vk!=VK_PAGE_DOWN && vk!=VK_CAPITAL);
-}
-
-int EditText(int vk,int shift,int control, char* txt,int& cur, int max)
-{
-	//returns 1 if TAB or ENTER was pressed
-	max--;
-	if (vk==8) //VK_BACKSPACE
-	{
-		if (cur>0)
-		{
-			cur--;
-			for(int j=cur; j<=max-1; j++) txt[j]=txt[j+1];
-			txt[max]=' ';
-		}
-	}
-	else
-	if (vk==VK_TAB || vk==13)		//VK_ENTER
-	{
-		return 1;
-	}
-	else
-	if (vk==VK_INSERT)
-	{
-		for(int j=max-1; j>=cur; j--) txt[j+1]=txt[j];
-		txt[cur]=' ';
-	}
-	else
-	if (vk==VK_DELETE)
-	{
-		for(int j=cur; j<=max-1; j++) txt[j]=txt[j+1];
-		txt[max]=' ';
-	}
-	else
-	{
-		if (control) return 0;
-		char a=0;
-		if (vk>=65 && vk<=90) {	a = (shift)? vk : vk+32; }		//letters - uppercase with SHIFT
-		else
-		if (vk>=48 && vk<=57) { a = (shift)? *(")!@#$%^&*("+vk-48): vk; }			//numbers - special characters with SHIFT
-		else
-		if (vk==' ')			a = ' ';	//space
-		else
-		if (vk==189)	a= (shift)? '_':'-';
-		else
-		if (vk==187)	a= (shift)? '+':'=';
-		else
-		if (vk == 219)	a=(shift)? '{' : '[';
-		else
-		if (vk == 221)	a=(shift)? '}' : ']';
-		else
-		if (vk==186)	a= (shift)? ':':';';
-		else
-		if (vk==222)	a= (shift)? '"':'\'';
-		else
-		if (vk == 188)	a = (shift) ? '<' : ',';
-		else
-		if (vk == 190)	a = (shift) ? '>' : '.';
-		else
-		if (vk==191)	a= (shift)? '?':'/';
-		else
-		if (vk==220)	a= (shift)? '|':'\\';
-		else
-		if (vk==VK_RIGHT)
-		{
-			if (cur<max) cur++;
-		}
-		else
-		if (vk==VK_LEFT)
-		{
-			if (cur>0) cur--;
-		}
-		else
-		if (vk==VK_HOME) cur=0;
-		else
-		if (vk==VK_END)
-		{
-			int j;
-			for (j = max; j >= 0 && (txt[j] == ' '); j--);
-			cur=(j<max)? j+1:max;
-		}
-
-		if (a>0)
-		{
-			for(int j=max-1; j>=cur; j--) txt[j+1]=txt[j];
-			txt[cur]=a;
-			if (cur<max) cur++;
-		}
-	}
-	return 0;
-}
-
-void WaitForTimerRoutineProcessed()
-{
-	g_timerroutineprocessed=0;
-	while(!g_timerroutineprocessed) Sleep(1);		//waiting
-}
-
-void StrToAtariVideo(char* txt,int count)
-{
-	char a;
-	for(int i=0; i<count; i++)
-	{
-		a=txt[i] & 0x7f;
-		if (a<32) a=0;
-		else
-		if (a<96) a-=32;
-		txt[i]=a;
-	}
-}
+extern void TextXY(char* txt, int x, int y, int color = TEXT_COLOR_WHITE);
+extern void TextXYSelN(char* txt, int n, int x, int y, int color = TEXT_COLOR_WHITE);
+extern void TextXYCol(char* txt, int x, int y, char* col);
+extern void TextDownXY(char* txt, int x, int y, int color = TEXT_COLOR_WHITE);
+extern void NumberMiniXY(BYTE num, int x, int y, int color = TEXT_MINI_COLOR_GRAY);
+extern void TextMiniXY(char* txt, int x, int y, int color = TEXT_MINI_COLOR_GRAY);
+extern void IconMiniXY(int icon, int x, int y);
+extern void GetTracklineText(char* dest, int line);
+extern void UpdateShiftControlKeys();
+extern BOOL IsnotMovementVKey(int vk);
+extern int EditText(int vk, int shift, int control, char* txt, int& cur, int max);
+extern void WaitForTimerRoutineProcessed();
+extern void StrToAtariVideo(char* txt, int count);
 
 //----
 
-void SetChannelOnOff(int ch,int onoff)
-{
-	if (ch<0)
-	{	//all channels
-		if (onoff>=0)
-			for(int i=0; i<SONGTRACKS; i++) g_channelon[i] = onoff;	//Settings
-		else
-			for(int i=0; i<SONGTRACKS; i++) g_channelon[i] ^= 1;	//invert
-	}
-	else
-	if (ch<SONGTRACKS)
-	{	//just that one
-		if (onoff>=0)
-			g_channelon[ch] = onoff;	//Settings
-		else
-			g_channelon[ch] ^= 1;	//invert
-	}
-}
-
-int GetChannelOnOff(int ch)	
-{ 
-	return g_channelon[ch]; 
-}
-
-void SetChannelSolo(int ch)
-{
-	int on = GetChannelOnOff(ch);
-	if (!on)
-	{
-Channel_SOLO:
-		SetChannelOnOff(-1,0);	//all off
-		SetChannelOnOff(ch,1);	//and solo only active
-	}
-	else
-	{
-		for(int i=0; i<g_tracks4_8; i++)
-		{
-			if(i!=ch && GetChannelOnOff(i)) goto Channel_SOLO;
-		}
-		SetChannelOnOff(-1,1);	//turn them all on
-	}
-}
+extern void SetChannelOnOff(int ch, int onoff);
+extern int GetChannelOnOff(int ch);
+extern void SetChannelSolo(int ch);
 
 //debug display of g_atarimem bytes directly, slow and terrible, do not use unless there is a purpose for it 
-void GetAtariMemHexStr(int adr, int len)
-{
-	unsigned int a = 0;
-	char c[8] = { 0 };
-	memset(g_debugmem, 0, 65536);
-	for (int i = 0; i < len; i++)
-	{
-		a = g_atarimem[adr + i];
-		sprintf(c, "$%x, ", a);
-		g_debugmem[i * 4] = c[0];	//$
-		//force uppercase on characters "a" to "f"
-		if (c[1] >= 0x61 && c[1] < 0x67) c[1] -= 0x20;
-		if (c[2] >= 0x61 && c[2] < 0x67) c[2] -= 0x20;
-		if (a > 0xF)	//0x10 and above
-		{
-			g_debugmem[(i * 4) + 1] = c[1];	//nybble 1
-			g_debugmem[(i * 4) + 2] = c[2];	//nybble 2
-		}
-		else	//single digit hex character, add padding 0
-		{
-			g_debugmem[(i * 4) + 1] = '0';	//nybble 1
-			g_debugmem[(i * 4) + 2] = c[1];	//nybble 2
-		}
-		if (i != len - 1) g_debugmem[(i * 4) + 3] = ','; 
-		else g_debugmem[(i * 4) + 3] = ' ';	//, or space if last character
-	}
-}
+extern void GetAtariMemHexStr(int adr, int len);
 
 //----
 
-const char keynotes[256]=
-{
-//0
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, 27, -1,
-//50
-	13, 15, -1, 18, 20, 22, -1, 25, -1, -1,
-	-1, -1, -1, -1, -1, -1,  7,  4,  3, 16,
-	-1,  6,  8, 24, 10, -1, 13, 11,  9, 26,
-	28, 12, 17,  1, 19, 23,  5, 14,  2, 21,
-	 0, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-//100
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-//150
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, 15, 30, 12, -1,
-	14, 16, -1, -1, -1, -1, -1, -1, -1, -1,
-//200
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, 29,
-	-1, 31, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-//250
-	-1, -1, -1, -1, -1, -1
-};
+extern const char keynotes[256];
+extern const char keynumbs[256];
+extern const char keynumblock09[256];
 
-const char keynumbs[256]=
-{
-//0
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, -1, -1,
-//64
-	-1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-//128
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-//192
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-};
-
-const char keynumblock09[256]=
-{
-//0
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-//64
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-//128
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-//192
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-};
-
-char NoteKey(int vk)	{ return keynotes[vk]; };
-char NumbKey(int vk)	{ return keynumbs[vk]; };
-char Numblock09Key(int vk)	{ return keynumblock09[vk]; };
+extern char NoteKey(int vk);
+extern char NumbKey(int vk);
+extern char Numblock09Key(int vk);
 
 #endif

--- a/cpp_src/r_music.cpp
+++ b/cpp_src/r_music.cpp
@@ -115,6 +115,34 @@ BOOL ModifyTrack(TTrack *track,int from,int to,int instrnumonly,int tuning,int i
 	return 1;
 }
 
+BOOL NextSegment(std::ifstream& in)
+{
+	char b;
+	while (!in.eof())
+	{
+		in.read((char*)&b, 1);
+		if (b == '[') return 1;	//end of segment (beginning of something else)
+	}
+	return 0;
+}
+
+void Trimstr(char* txt)
+{
+	char a;
+	for (int i = 0; (a = txt[i]); i++)
+	{
+		if (a == 13 || a == 10)
+		{
+			txt[i] = 0;
+			return;
+		}
+	}
+}
+
+char CharH4(unsigned char b) { BYTE i = b >> 4; return ((BYTE)i + ((i < 10) ? 48 : 55)); };
+char CharL4(unsigned char b) { BYTE i = b & 0x0f; return ((BYTE)i + ((i < 10) ? 48 : 55)); };
+
+
 //-------
 
 CTrackClipboard::CTrackClipboard()
@@ -1443,7 +1471,7 @@ BOOL CInstruments::DrawInstrument(int it)
 	TInstrument& t = m_instr[it];
 
 	sprintf(s,"INSTRUMENT %02X",it);
-	TextXY(s,INSTRS_X,INSTRS_Y,0);
+	TextXY(s, INSTRS_X, INSTRS_Y, TEXT_COLOR_WHITE);
 	int size=(t.par[PAR_ENVLEN]+1)*3+(t.par[PAR_TABLEN]+1)+12;
 	sprintf(s,"(SIZE %u BYTES)",size);
 	TextMiniXY(s,INSTRS_X+14*8,INSTRS_Y+5);
@@ -1454,23 +1482,23 @@ BOOL CInstruments::DrawInstrument(int it)
 	TextMiniXY("ENVELOPE",INSTRS_PX+15*8,INSTRS_PY+16+8);
 	TextMiniXY("TABLE",INSTRS_PX+15*8,INSTRS_PY+8*16+8);
 	//
-	TextDownXY("\x0e\x0e\x0e\x0e", INSTRS_EX+11*8-1,INSTRS_EY+3*16,1);
+	TextDownXY("\x0e\x0e\x0e\x0e", INSTRS_EX + 11 * 8 - 1, INSTRS_EY + 3 * 16, TEXT_COLOR_GRAY);
 	
 	if (t.act==2)	//only when the cursor is on the envelope edit
 	{
 		sprintf(s,"POS %02X",t.activeenvx);
-		TextXY(s,INSTRS_EX+2*8,INSTRS_EY+5*16,1); 
+		TextXY(s, INSTRS_EX + 2 * 8, INSTRS_EY + 5 * 16, TEXT_COLOR_GRAY);
 	}
 	//
 	for(i=1; i<ENVROWS; i++) //omits "VOLUME R:"
 	{
-		TextXY(shenv[i].name, shenv[i].xpos, shenv[i].ypos,0);
+		TextXY(shenv[i].name, shenv[i].xpos, shenv[i].ypos, TEXT_COLOR_WHITE);
 	}
 
 	if (g_tracks4_8>4)
 	{
-		TextXY(shenv[0].name, shenv[0].xpos, shenv[0].ypos,0); //"VOLUME R:"
-		TextDownXY("\x0e\x0e\x0e\x0e", INSTRS_EX+11*8-1,INSTRS_EY-2*16,1);
+		TextXY(shenv[0].name, shenv[0].xpos, shenv[0].ypos, TEXT_COLOR_WHITE); //"VOLUME R:"
+		TextDownXY("\x0e\x0e\x0e\x0e", INSTRS_EX + 11 * 8 - 1, INSTRS_EY - 2 * 16, TEXT_COLOR_GRAY);
 		g_mem_dc->MoveTo(((INSTRS_EX + 12 * 8 - 1) * sp) / 100, ((INSTRS_EY + 2 * 16 - 1) * sp) / 100);
 		g_mem_dc->LineTo(((INSTRS_EX + 12 * 8 + ENVCOLS * 8) * sp) / 100, ((INSTRS_EY + 2 * 16 - 1) * sp) / 100);
 	}
@@ -1498,7 +1526,7 @@ BOOL CInstruments::DrawInstrument(int it)
 	if (go<len)
 	{
 		s[0]='\x07';	//Go from here
-		TextXY(s,INSTRS_EX+12*8+len*8,INSTRS_EY+7*16,0);
+		TextXY(s, INSTRS_EX + 12 * 8 + len * 8, INSTRS_EY + 7 * 16, TEXT_COLOR_WHITE);
 		s[0]='\x06';	//Go here
 
 		int lengo = len-go;
@@ -1506,7 +1534,7 @@ BOOL CInstruments::DrawInstrument(int it)
 	}
 	else
 		s[0]='\x16';	//GO from here to here
-	TextXY(s,INSTRS_EX+12*8+go*8,INSTRS_EY+7*16,0);
+	TextXY(s, INSTRS_EX + 12 * 8 + go * 8, INSTRS_EY + 7 * 16, TEXT_COLOR_WHITE);
 	if (go>2) NumberMiniXY(go,INSTRS_EX+11*8+go*4,INSTRS_EY+7*16+4); //GO number
 
 	//TABLE
@@ -1517,12 +1545,12 @@ BOOL CInstruments::DrawInstrument(int it)
 	go = t.par[PAR_TABGO];		//table GO loop
 	if (len==0)
 	{
-		TextXY("\x18",INSTRS_TX+4,INSTRS_TY+8+16,0);
+		TextXY("\x18", INSTRS_TX + 4, INSTRS_TY + 8 + 16, TEXT_COLOR_WHITE);
 	}
 	else
 	{
-		TextXY("\x19",INSTRS_TX+go*8*3,INSTRS_TY+8+16,0);
-		TextXY("\x1a",INSTRS_TX+8+len*8*3,INSTRS_TY+8+16,0);
+		TextXY("\x19", INSTRS_TX + go * 8 * 3, INSTRS_TY + 8 + 16, TEXT_COLOR_WHITE);
+		TextXY("\x1a", INSTRS_TX + 8 + len * 8 * 3, INSTRS_TY + 8 + 16, TEXT_COLOR_WHITE);
 	}
 
 	//delimitation of space for Envelope VOLUME
@@ -1565,7 +1593,7 @@ BOOL CInstruments::DrawInstrument(int it)
 				"Distortion C, buzzy bass tones. (AUDC $Cv, Poly4)",
 				"Distortion C, gritty bass tones. (AUDC $Cv, Poly4)" };
 			char* hs = distor_help[(d>>1)&0x07];
-			TextXY(hs,INSTRS_HX,INSTRS_HY,1);
+			TextXY(hs, INSTRS_HX, INSTRS_HY, TEXT_COLOR_GRAY);
 			//HORIZONTALLINE;
 			}
 			break;
@@ -1583,7 +1611,7 @@ BOOL CInstruments::DrawInstrument(int it)
 				"Set FILTER_SHFRQ += $XY. $0Y = BASS16 Distortion. $FF/$01 = Sawtooth inversion (Distortion A).",
 				"Set instrument AUDCTL. $FF = VOLUME ONLY mode. $FE/$FD = enable/disable Two-Tone Filter." };
 			char* hs = comm_help[c & 0x07];
-			TextXY(hs,INSTRS_HX,INSTRS_HY,1);
+			TextXY(hs, INSTRS_HX, INSTRS_HY, TEXT_COLOR_GRAY);
 			//HORIZONTALLINE;
 			}
 			break;
@@ -1593,7 +1621,7 @@ BOOL CInstruments::DrawInstrument(int it)
 			{
 			char i = (t.env[t.activeenvx][ENV_X]<<4) | t.env[t.activeenvx][ENV_Y];
 			sprintf(s,"XY: $%02X = %i = %+i",(unsigned char)i,(unsigned char)i,i);
-			TextXY(s,INSTRS_HX,INSTRS_HY,1);
+			TextXY(s, INSTRS_HX, INSTRS_HY, TEXT_COLOR_GRAY);
 			//HORIZONTALLINE;
 			}
 			break;
@@ -1612,7 +1640,7 @@ BOOL CInstruments::DrawInstrument(int it)
 				sprintf(s,"$%02X = %i",i,i);
 			else
 				sprintf(s,"$00 = no effects.");
-			TextXY(s,INSTRS_HX,INSTRS_HY,1);
+			TextXY(s, INSTRS_HX, INSTRS_HY, TEXT_COLOR_GRAY);
 			//HORIZONTALLINE;
 			}
 			break;
@@ -1627,7 +1655,7 @@ BOOL CInstruments::DrawInstrument(int it)
 			else
 				f = (double)i/256 + 0.0005;
 			sprintf(s,"$%02X = -%.3f / vbi",(unsigned char)i,f);
-			TextXY(s,INSTRS_HX,INSTRS_HY,1);
+			TextXY(s, INSTRS_HX, INSTRS_HY, TEXT_COLOR_GRAY);
 			//HORIZONTALLINE;
 			}
 			break;
@@ -1638,7 +1666,7 @@ BOOL CInstruments::DrawInstrument(int it)
 		is_editing_instr = 0;
 		char i = (t.tab[t.activetab]);
 		sprintf(s,"$%02X = %+i",(unsigned char)i,i);
-		TextXY(s,INSTRS_HX,INSTRS_HY,1);
+		TextXY(s, INSTRS_HX, INSTRS_HY, TEXT_COLOR_GRAY);
 		//HORIZONTALLINE;
 	}
 	return 1;
@@ -1647,19 +1675,19 @@ BOOL CInstruments::DrawInstrument(int it)
 BOOL CInstruments::DrawName(int it)
 {
 	char* s=GetName(it);
-	int n=-1,c=0;
+	int n = -1, color = TEXT_COLOR_WHITE;
 
 	if (g_activepart==PARTINSTRS && m_instr[it].act==0)  //is an active change of instrument name
 	{
 		n=m_instr[it].activenam;
-		if (g_prove) c=13; //blue
-		else c=6; //red
+		if (g_prove) color = TEXT_COLOR_BLUE;
+		else color = TEXT_COLOR_RED;
 		is_editing_instr = 1;
 	}
-	else c=14; //light gray
+	else color = TEXT_COLOR_LIGHT_GRAY;
 
-	TextXY("NAME:",INSTRS_X,INSTRS_Y+16,0);
-	TextXYSelN(s,n,INSTRS_X+6*8,INSTRS_Y+16,c);
+	TextXY("NAME:", INSTRS_X, INSTRS_Y + 16, TEXT_COLOR_WHITE);
+	TextXYSelN(s,n,INSTRS_X+6*8,INSTRS_Y+16,color);
 	return 1;
 }
 
@@ -1673,18 +1701,18 @@ BOOL CInstruments::DrawPar(int p,int it)
 	int y=shpar[p].y;
 
 	char a;
-	int c=0;	//c<<4;
+	int color = TEXT_COLOR_WHITE;
 
 	for (int i = 0; a = (txt[i]); i++, x += 8)
 	{
 		//necessary! this is a custom textxy function for displaying instruments...
-		g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (16 * sp) / 100, g_gfx_dc, (a & 0x7f) << 3, c, 8, 16, SRCCOPY);
+		g_mem_dc->StretchBlt((x * sp) / 100, (y * sp) / 100, (8 * sp) / 100, (16 * sp) / 100, g_gfx_dc, (a & 0x7f) << 3, color, 8, 16, SRCCOPY);
 	}
 
 	//if the cursor is on the main parameters
 	if (g_activepart==PARTINSTRS && m_instr[it].act==1 && m_instr[it].activepar==p)
 	{
-		c = (g_prove) ? COLOR_SELECTED_PROVE : COLOR_SELECTED;
+		color = (g_prove) ? COLOR_SELECTED_PROVE : COLOR_SELECTED;
 	}
 
 	x+=8;
@@ -1693,12 +1721,12 @@ BOOL CInstruments::DrawPar(int p,int it)
 	if (shpar[p].pmax+shpar[p].pfrom>0x0f)
 	{
 		s[0]=CharH4(showpar);
-		TextXY(s,x,y,c);
+		TextXY(s,x,y,color);
 	}
 
 	x+=8;
 	s[0]=CharL4(showpar);
-	TextXY(s,x,y,c);	
+	TextXY(s,x,y,color);	
 
 	return 1;
 }
@@ -1932,26 +1960,26 @@ BOOL CInstruments::GetInstrArea(int instr, int zone, CRect& rect)
 	return 0;
 }
 
-BOOL CInstruments::DrawEnv(int e, int it)
+void CInstruments::DrawEnv(int e, int it)
 {
 	int sp = g_scaling_percentage;
 	TInstrument& in = m_instr[it];
 	int volR= in.env[e][ENV_VOLUMER] & 0x0f; //volume right
 	int volL= in.env[e][ENV_VOLUMEL] & 0x0f; //volume left/mono
-	int c;
+	int color;
 	int x=INSTRS_EX+12*8+e*8;
 	char s[2],a;
 	s[1]=0;
 	int ay= (in.act==2 && in.activeenvx==e)? in.activeenvy : -1;
 
 	//Volume Only mode uses Command 7 with $XY == $FF
-	COLORREF color = (in.env[e][ENV_COMMAND]==0x07 && in.env[e][ENV_X]==0x0f && in.env[e][ENV_Y]==0x0f) ?
+	COLORREF fillColor = (in.env[e][ENV_COMMAND]==0x07 && in.env[e][ENV_X]==0x0f && in.env[e][ENV_Y]==0x0f) ?
 		RGB(128,255,255) : RGB(255,255,255);
 
 	//volume column
-	if (volL) g_mem_dc->FillSolidRect((x * sp) / 100, ((INSTRS_EY + 3 * 16 + 4 + 4 * (15 - volL)) * sp) / 100, (8 * sp) / 100, ((volL * 4) * sp) / 100, color);
+	if (volL) g_mem_dc->FillSolidRect((x * sp) / 100, ((INSTRS_EY + 3 * 16 + 4 + 4 * (15 - volL)) * sp) / 100, (8 * sp) / 100, ((volL * 4) * sp) / 100, fillColor);
 
-	if (g_tracks4_8 > 4 && volR) g_mem_dc->FillSolidRect((x * sp) / 100, ((INSTRS_EY - 2 * 16 + 4 + 4 * (15 - volR)) * sp) / 100, (8 * sp) / 100, ((volR * 4) * sp) / 100, color);
+	if (g_tracks4_8 > 4 && volR) g_mem_dc->FillSolidRect((x * sp) / 100, ((INSTRS_EY - 2 * 16 + 4 + 4 * (15 - volR)) * sp) / 100, (8 * sp) / 100, ((volR * 4) * sp) / 100, fillColor);
 
 	for(int j=0; j<8; j++)
 	{
@@ -1967,18 +1995,17 @@ BOOL CInstruments::DrawEnv(int e, int it)
 
 		if (j==ay && g_activepart==PARTINSTRS)
 		{
-			c = (g_prove) ? COLOR_SELECTED_PROVE : COLOR_SELECTED;
+			color = (g_prove) ? COLOR_SELECTED_PROVE : COLOR_SELECTED;
 		}
-		else c = 0;
+		else color = TEXT_COLOR_WHITE;
 
 		if (j==0)
 		{
-			if (g_tracks4_8>4) TextXY(s,x,INSTRS_EY+2*16,c);		 //volume R is out of the box
+			if (g_tracks4_8>4) TextXY(s,x,INSTRS_EY+2*16,color);		 //volume R is out of the box
 		}
 		else
-			TextXY(s,x,INSTRS_EY+7*16+j*16,c);
+			TextXY(s,x,INSTRS_EY+7*16+j*16,color);
 	}
-	return 1;
 }
 
 BOOL CInstruments::DrawTab(int p,int it)
@@ -1995,14 +2022,14 @@ BOOL CInstruments::DrawTab(int p,int it)
 	//table parameter
 	sprintf(s,"%02X",in.tab[p]);
 
-	int c = 0;
+	int color = TEXT_COLOR_WHITE;
 
 	if (in.act==3 && in.activetab==p && g_activepart==PARTINSTRS)
 	{
-		c = (g_prove) ? COLOR_SELECTED_PROVE : COLOR_SELECTED;
+		color = (g_prove) ? COLOR_SELECTED_PROVE : COLOR_SELECTED;
 	}
 
-	TextXY(s,INSTRS_TX+p*24,INSTRS_TY+8,c);
+	TextXY(s, INSTRS_TX + p * 24, INSTRS_TY + 8, color);
 	return 1;
 }
 
@@ -2591,7 +2618,7 @@ BOOL CTracks::DrawTrack(int col, int x, int y, int tr, int line_cnt, int aline, 
 {
 	//cactview = cursor active view line
 	char s[16];
-	int i,line,xline,n,c,len,last,go;
+	int i,line,xline,n,color,len,last,go;
 
 	len=last=0;
 	TTrack *tt=NULL;
@@ -2626,8 +2653,8 @@ BOOL CTracks::DrawTrack(int col, int x, int y, int tr, int line_cnt, int aline, 
 			}
 		}
 	}
-	c = (GetChannelOnOff(col))? 0 : 1;
-	TextXY(s,x+8,y,c);
+	color = (GetChannelOnOff(col))? TEXT_COLOR_WHITE : TEXT_COLOR_GRAY;
+	TextXY(s,x+8,y,color);
 	y+=32;
 
 	for (i = 0; i < line_cnt; i++, y += 16)
@@ -2638,20 +2665,20 @@ BOOL CTracks::DrawTrack(int col, int x, int y, int tr, int line_cnt, int aline, 
 		if (line>=last)
 		{
 			if (line == aline && isactive)
-				c = (g_prove) ? 13 : 6;	//blue or red
+				color = (g_prove) ? TEXT_COLOR_BLUE : TEXT_COLOR_RED;
 			else if (line == pline)
-				c=2;	//yellow
-			else 
-				c=1;	//gray
+				color = TEXT_COLOR_YELLOW;
+			else
+				color = TEXT_COLOR_GRAY;
 			
 			if (line==last && len>0)
 			{
-				if (c!=13 && c!=6) c=0;	//The end is white unless the active colour is used
-				TextXY("\x12\x12\x12\x12\x12\x13\x14\x15\x12\x12\x12\x12\x12", x + 1 * 8, y, c);
+				if (color != TEXT_COLOR_BLUE && color != TEXT_COLOR_RED) color = TEXT_COLOR_WHITE;	//The end is white unless the active colour is used
+				TextXY("\x12\x12\x12\x12\x12\x13\x14\x15\x12\x12\x12\x12\x12", x + 1 * 8, y, color);
 			}
 			else
 				//empty track line
-				TextXY(" \x8\x8\x8 \x8\x8 \x8\x8 \x8\x8\x8", x, y, c);
+				TextXY(" \x8\x8\x8 \x8\x8 \x8\x8 \x8\x8\x8", x, y, color);
 			continue;
 		}
 		strcpy(s, " --- -- -- ---");
@@ -2726,15 +2753,15 @@ BOOL CTracks::DrawTrack(int col, int x, int y, int tr, int line_cnt, int aline, 
 
 		//colours
 		if (line == aline && isactive)
-			c = (g_prove) ? 13 : 6;	//blue or red
+			color = (g_prove) ? TEXT_COLOR_BLUE : TEXT_COLOR_RED;
 		else if (line == pline)
-			c = 2;	//yellow
-		else if (line >= len) 
-			c = 1;	//gray 
-		else if ((line % g_tracklinehighlight) == 0) 
-			c = 5;	//cyan
+			color = TEXT_COLOR_YELLOW;
+		else if (line >= len)
+			color = TEXT_COLOR_GRAY;
+		else if ((line % g_tracklinehighlight) == 0)
+			color = TEXT_COLOR_CYAN;
 		else
-			c = 0;	//white
+			color = TEXT_COLOR_WHITE;
 
 		if (g_activepart==PARTTRACKS && line<len && (line == aline && isactive))
 		{
@@ -2742,7 +2769,7 @@ BOOL CTracks::DrawTrack(int col, int x, int y, int tr, int line_cnt, int aline, 
 			else TextXYCol(s,x,y,colac[acu]);
 		}
 		else
-			TextXY(s,x,y,c);
+			TextXY(s,x,y,color);
 	}
 	return 1;
 }
@@ -6828,7 +6855,7 @@ BOOL CSong::PlayPressedTones()
 BOOL CSong::DrawSong()
 {
 	int line,i,j,k,y,t;
-	char s[32],c;
+	char s[32],color;
 	int sp = g_scaling_percentage;
 
 	int MINIMAL_WIDTH_TRACKS = (g_tracks4_8 > 4 && g_active_ti == 1) ? 1420 : 960;
@@ -6838,7 +6865,7 @@ BOOL CSong::DrawSong()
 	if (g_tracks4_8 == 4 && g_active_ti == 2 && g_width > MINIMAL_WIDTH_INSTRUMENTS - 220) INSTRUMENT_OFFSET = 260;
 	int SONG_OFFSET = SONG_X + WINDOW_OFFSET + INSTRUMENT_OFFSET + ((g_tracks4_8 == 4) ? -200 : 310);	//displace the SONG block depending on certain parameters
 
-	TextXY("SONG", SONG_OFFSET + 8, SONG_Y,0);
+	TextXY("SONG", SONG_OFFSET + 8, SONG_Y, TEXT_COLOR_WHITE);
 
 	//print L1 .. L4 R1 .. R4 with highlighted current track
 	k=SONG_OFFSET+6*8;
@@ -6849,11 +6876,11 @@ BOOL CSong::DrawSong()
 		s[1]=i+49;	//character 1-4
 		if (GetChannelOnOff(i))
 		{
-			if (m_trackactivecol == i) c = (g_prove) ? 13 : 6;	//active channel highlight
-			else c = 0; //normal channel
+			if (m_trackactivecol == i) color = (g_prove) ? TEXT_COLOR_BLUE : TEXT_COLOR_RED;	//active channel highlight
+			else color = TEXT_COLOR_WHITE; //normal channel
 		}
-		else c = 1; //switched off channels are in gray
-		TextXY(s,k,SONG_Y,c);
+		else color = TEXT_COLOR_GRAY; //switched off channels are in gray
+		TextXY(s, k, SONG_Y, color);
 	}
 	s[0]='R';
 	for(i=4; i<g_tracks4_8; i++,k+=24)
@@ -6861,11 +6888,11 @@ BOOL CSong::DrawSong()
 		s[1]=i+49-4;	//character 1-4
 		if (GetChannelOnOff(i))
 		{
-			if (m_trackactivecol==i) c = (g_prove) ? 13 : 6;	//active channel highlight
-			else c=0; //normal channel
+			if (m_trackactivecol==i) color = (g_prove) ? 13 : 6;	//active channel highlight
+			else color=0; //normal channel
 		}
-		else c=1; //switched off channels are in gray
-		TextXY(s,k,SONG_Y,c);
+		else color=1; //switched off channels are in gray
+		TextXY(s, k, SONG_Y, color);
 	}
 
 	y=SONG_Y+16;
@@ -6880,22 +6907,22 @@ BOOL CSong::DrawSong()
 		strcpy(s,"XX:");
 		s[0]= CharH4(line);
 		s[1]= CharL4(line);
-		c = (line==m_songplayline)? 2:0;
-		TextXY(s,SONG_OFFSET+16,y,c);
+		color = (line==m_songplayline)? 2:0;
+		TextXY(s, SONG_OFFSET + 16, y, color);
 
 		if ((j=m_songgo[line])>=0)	//there is a GO to line
 		{
 			s[0]=CharH4(j);
 			s[1]=CharL4(j);
 			s[2]=0;
-			TextXY("Go\x1fto\x1fline", SONG_OFFSET + 16, y, 14);	//turquoise text, blank tiles to mask text if needed
-			c = 0;	//white, for the number used
+			TextXY("Go\x1fto\x1fline", SONG_OFFSET + 16, y, TEXT_COLOR_LIGHT_GRAY);	//turquoise text, blank tiles to mask text if needed
+			color = TEXT_COLOR_WHITE;	//white, for the number used
 			if (line == m_songactiveline)
 			{
-				if (g_prove) c = (g_activepart == PARTSONG) ? COLOR_SELECTED_PROVE : 13;
-				else c = (g_activepart == PARTSONG) ? COLOR_SELECTED : 6;
+				if (g_prove) color = (g_activepart == PARTSONG) ? COLOR_SELECTED_PROVE : TEXT_COLOR_BLUE;
+				else color = (g_activepart == PARTSONG) ? COLOR_SELECTED : TEXT_COLOR_RED;
 			}
-			TextXY(s, SONG_OFFSET + 16 + 11 * 8, y, c);
+			TextXY(s, SONG_OFFSET + 16 + 11 * 8, y, color);
 		}
 		else	//there are track numbers
 		{
@@ -6910,17 +6937,17 @@ BOOL CSong::DrawSong()
 				else s[0]=s[1]='-';	//--
 				if (line==m_songactiveline && j==m_trackactivecol)
 				{
-					if (g_prove) c = (g_activepart == PARTSONG) ? COLOR_SELECTED_PROVE : 13;
-					else c = (g_activepart == PARTSONG) ? COLOR_SELECTED : 6;
+					if (g_prove) color = (g_activepart == PARTSONG) ? COLOR_SELECTED_PROVE : TEXT_COLOR_BLUE;
+					else color = (g_activepart == PARTSONG) ? COLOR_SELECTED : TEXT_COLOR_RED;
 				}
-				else c = (line==m_songplayline)? 2:0;
-				TextXY(s,SONG_OFFSET+16+k,y,c);
+				else color = (line == m_songplayline) ? TEXT_COLOR_YELLOW : TEXT_COLOR_WHITE;
+				TextXY(s, SONG_OFFSET + 16 + k, y, color);
 			}
 		}
 	}
-	c = (g_prove) ? 13 : 6;
+	color = (g_prove) ? TEXT_COLOR_BLUE : TEXT_COLOR_RED;
 	int arrowpos = (WINDOW_OFFSET) ? SONG_Y + 48 : SONG_Y + 80;
-	TextXY("\x04\x05", SONG_OFFSET, arrowpos, c);	//arrow on current song line
+	TextXY("\x04\x05", SONG_OFFSET, arrowpos, color);	//arrow on current song line
 
 	if (g_tracks4_8 > 4)	//a line delimiting the boundary between left/right
 	{
@@ -6943,18 +6970,18 @@ BOOL CSong::DrawTracks()
 {
 	static char* tnames="L1L2L3L4R1R2R3R4";
 	char s[16],stmp[16];
-	int i,x,y,tr,line,c;
+	int i,x,y,tr,line,color;
 	int t;
 	int sp = g_scaling_percentage;
 
 	if (SongGetGo()>=0)		//it's a GOTO line, it won't draw tracks
 	{
 		int TRACKS_OFFSET = (g_tracks4_8 == 8) ? 62 : 30;
-		TextXY("Go to line ", TRACKS_X + TRACKS_OFFSET * 8, TRACKS_Y + 8 * 16, 14);
-		if (g_prove) c = (g_activepart == PARTTRACKS) ? COLOR_SELECTED_PROVE : 13;
-		else c = (g_activepart == PARTTRACKS) ? COLOR_SELECTED : 6;
+		TextXY("Go to line ", TRACKS_X + TRACKS_OFFSET * 8, TRACKS_Y + 8 * 16, TEXT_COLOR_LIGHT_GRAY);
+		if (g_prove) color = (g_activepart == PARTTRACKS) ? COLOR_SELECTED_PROVE : TEXT_COLOR_BLUE;
+		else color = (g_activepart == PARTTRACKS) ? COLOR_SELECTED : TEXT_COLOR_RED;
 		sprintf(s,"%02X",SongGetGo());
-		TextXY(s,TRACKS_X + TRACKS_OFFSET * 8 + 11 * 8,TRACKS_Y + 8 * 16,c);
+		TextXY(s, TRACKS_X + TRACKS_OFFSET * 8 + 11 * 8, TRACKS_Y + 8 * 16, color);
 		return 1;
 	}
 
@@ -6983,11 +7010,11 @@ BOOL CSong::DrawTracks()
 			s[0]=CharH4(line);
 			s[1]=CharL4(line);
 		}
-		if (line == m_trackactiveline) c = (g_prove) ? 13 : 6;	//red or blue
-		else if (line == m_trackplayline) c=2;	//yellow
-		else if ((line % g_tracklinehighlight) == 0) c=5;	//blue
-		else c=0;	//white
-		TextXY(s,TRACKS_X,y,c);
+		if (line == m_trackactiveline) color = (g_prove) ? TEXT_COLOR_BLUE : TEXT_COLOR_RED;	//red or blue
+		else if (line == m_trackplayline) color = TEXT_COLOR_YELLOW;
+		else if ((line % g_tracklinehighlight) == 0) color = TEXT_COLOR_CYAN;
+		else color = TEXT_COLOR_WHITE;
+		TextXY(s, TRACKS_X, y, color);
 	}
 
 	//tracks
@@ -6998,8 +7025,8 @@ BOOL CSong::DrawTracks()
 		s[8] = tnames[i * 2];
 		s[9] = tnames[i * 2 + 1];
 
-		c = (GetChannelOnOff(i)) ? 0 : 1;	//channels off are in gray
-		TextXY(s, x + 12, TRACKS_Y, c);
+		color = (GetChannelOnOff(i)) ? TEXT_COLOR_WHITE : TEXT_COLOR_GRAY;	//channels off are in gray
+		TextXY(s, x + 12, TRACKS_Y, color);
 		//track in the current line of the song
 		tr = m_song[m_songactiveline][i];
 		
@@ -7048,13 +7075,13 @@ BOOL CSong::DrawTracks()
 		GetTracklineText(s1,bfro);
 		GetTracklineText(s2,bto);
 		sprintf(tx,"%i line(s) [%s-%s] selected in the pattern track %02X",bto-bfro+1,s1,s2,g_trackcl.m_seltrack);
-		TextXY(tx, TRACKS_X + 4 * 8, TRACKS_Y + (4 + g_tracklines) * 16,0);
+		TextXY(tx, TRACKS_X + 4 * 8, TRACKS_Y + (4 + g_tracklines) * 16, TEXT_COLOR_WHITE);
 		x = TRACKS_X+4*8 + strlen(tx)*8 +8;
 		if (g_trackcl.m_all)
 			strcpy(tx,"[edit ALL data]");
 		else
 			sprintf(tx,"[edit data ONLY for instrument %02X]",m_activeinstr);
-		TextXY(tx, x, TRACKS_Y + (4 + g_tracklines) * 16, 6);
+		TextXY(tx, x, TRACKS_Y + (4 + g_tracklines) * 16, TEXT_COLOR_RED);
 	}
 
 	//lines delimiting the current line
@@ -7089,29 +7116,29 @@ BOOL CSong::DrawInstrument()
 BOOL CSong::DrawInfo()
 {
 	char s[80];
-	int i,c;
+	int i,color;
 	is_editing_infos = 0;
 
 	if (g_prove == 3)	//test mode exclusive from MIDI CH15 inputs, this cannot be set by accident unless I did something stupid
-		TextXY("EXPLORER MODE (MIDI CH15)", INFO_X, INFO_Y + 2 * 16, 14);
+		TextXY("EXPLORER MODE (MIDI CH15)", INFO_X, INFO_Y + 2 * 16, TEXT_COLOR_LIGHT_GRAY);
 	else if (g_prove > 0)
-		TextXY((g_prove == 1) ? "JAM MODE (MONO)" : "JAM MODE (STEREO)", INFO_X, INFO_Y + 2 * 16, 13);
+		TextXY((g_prove == 1) ? "JAM MODE (MONO)" : "JAM MODE (STEREO)", INFO_X, INFO_Y + 2 * 16, TEXT_COLOR_BLUE);
 	else
-		TextXY("EDIT MODE", INFO_X, INFO_Y + 2 * 16, 6);
+		TextXY("EDIT MODE", INFO_X, INFO_Y + 2 * 16, TEXT_COLOR_RED);
 
 	if (g_activepart==PARTINFO && m_infoact==0) //info? && edit name?
 	{
 		is_editing_infos = 1;
 		i=m_songnamecur;
-		if (g_prove) c=13; //blue
-		else c=6; //red
+		if (g_prove) color = TEXT_COLOR_BLUE;
+		else color = TEXT_COLOR_RED;
 	}
 	else
 	{
 		i=-1;
-		c=14; //light gray
+		color = TEXT_COLOR_LIGHT_GRAY;
 	}
-	TextXYSelN(m_songname,i,INFO_X,INFO_Y,c);
+	TextXYSelN(m_songname, i, INFO_X, INFO_Y, color);
 
 	sprintf(s,"MUSIC SPEED: %02X/%02X/%X  MAXTRACKLENGTH: %02X  %s  %s",
 		m_speed,m_mainspeed,m_instrspeed,
@@ -7120,54 +7147,54 @@ BOOL CSong::DrawInfo()
 		(g_ntsc)? "NTSC" : "PAL"
 		);
 
-	TextXY(s,INFO_X,INFO_Y+1*16,0);
+	TextXY(s, INFO_X, INFO_Y + 1 * 16, TEXT_COLOR_WHITE);
 
 	s[15]=0; //current speed
-	TextXY(s+13,INFO_X+13*8,INFO_Y+1*16,14);	//light gray
+	TextXY(s + 13, INFO_X + 13 * 8, INFO_Y + 1 * 16, TEXT_COLOR_LIGHT_GRAY);
 	s[18]=0; //main speed
-	TextXY(s+16,INFO_X+16*8,INFO_Y+1*16,14);	//light gray
+	TextXY(s + 16, INFO_X + 16 * 8, INFO_Y + 1 * 16, TEXT_COLOR_LIGHT_GRAY);
 	s[20]=0; //instrspeed
-	TextXY(s+19,INFO_X+19*8,INFO_Y+1*16,14);	//light gray
+	TextXY(s + 19, INFO_X + 19 * 8, INFO_Y + 1 * 16, TEXT_COLOR_LIGHT_GRAY);
 	s[64]=0; //MAXTRACKLENGTH value and everything after
-	TextXY(s+38,INFO_X+38*8,INFO_Y+1*16,14);	//light gray
+	TextXY(s + 38, INFO_X + 38 * 8, INFO_Y + 1 * 16, TEXT_COLOR_LIGHT_GRAY);
 
 	if (g_activepart==PARTINFO)
 	{
-		if (g_prove) c = COLOR_SELECTED_PROVE;
-		else c = COLOR_SELECTED;
+		if (g_prove) color = COLOR_SELECTED_PROVE;
+		else color = COLOR_SELECTED;
 		switch (m_infoact)
 		{
 		case 1:	//speed
 			s[15]=0; 
-			TextXY(s+13,INFO_X+13*8,INFO_Y+1*16,c);	//selected
+			TextXY(s + 13, INFO_X + 13 * 8, INFO_Y + 1 * 16, color);	//selected
 			break;
 		case 2: //mainspeed
 			s[18]=0; 
-			TextXY(s+16,INFO_X+16*8,INFO_Y+1*16,c);	//selected
+			TextXY(s + 16, INFO_X + 16 * 8, INFO_Y + 1 * 16, color);	//selected
 			break;
 		case 3: //instrspeed
 			s[20]=0; 
-			TextXY(s+19,INFO_X+19*8,INFO_Y+1*16,c);	//selected
+			TextXY(s + 19, INFO_X + 19 * 8, INFO_Y + 1 * 16, color);	//selected
 			break;
 		}
 	}
 
 	sprintf(s,"%02X: %s",m_activeinstr,m_instrs.GetName(m_activeinstr));
-	TextXY(s,INFO_X,INFO_Y+3*16,0);
+	TextXY(s, INFO_X, INFO_Y + 3 * 16, TEXT_COLOR_WHITE);
 	s[40]=0;
-	TextXY(s+4,INFO_X+4*8,INFO_Y+3*16,14);
+	TextXY(s + 4, INFO_X + 4 * 8, INFO_Y + 3 * 16, TEXT_COLOR_LIGHT_GRAY);
 
 	sprintf(s,"OCTAVE %i-%i",m_octave+1,m_octave+2);
-	TextXY(s,INFO_X+47*8,INFO_Y+3*16,0);
+	TextXY(s, INFO_X + 47 * 8, INFO_Y + 3 * 16, TEXT_COLOR_WHITE);
 	s[40]=0;
-	TextXY(s+7,INFO_X+54*8,INFO_Y+3*16,14);
+	TextXY(s + 7, INFO_X + 54 * 8, INFO_Y + 3 * 16, TEXT_COLOR_LIGHT_GRAY);
 
 	sprintf(s,"VOLUME %X",m_volume);
-	TextXY(s,INFO_X+49*8,INFO_Y+4*16,0);
+	TextXY(s, INFO_X + 49 * 8, INFO_Y + 4 * 16, TEXT_COLOR_WHITE);
 	s[40]=0;
-	TextXY(s+7,INFO_X+56*8,INFO_Y+4*16,14);
+	TextXY(s + 7, INFO_X + 56 * 8, INFO_Y + 4 * 16, TEXT_COLOR_LIGHT_GRAY);
 
-	if (g_respectvolume) TextXY("\x17",INFO_X+57*8,INFO_Y+4*16,0);	//respect volume mode
+	if (g_respectvolume) TextXY("\x17", INFO_X + 57 * 8, INFO_Y + 4 * 16, TEXT_COLOR_WHITE);	//respect volume mode
 
 	//over instrument line with flags
 	BYTE flag = m_instrs.GetFlag(m_activeinstr);
@@ -7180,15 +7207,15 @@ BOOL CSong::DrawInfo()
 	{
 		if (g>2) 
 		{
-			TextMiniXY("NO FILTER",x,y,0);	//gray
+			TextMiniXY("NO FILTER",x,y, TEXT_MINI_COLOR_GRAY);
 			x += 10*8;
 		}
 		else
 		{
-			if (g==1)
-				TextMiniXY("AUTOFILTER(1+3)",x,y,1);
+			if (g == 1)
+				TextMiniXY("AUTOFILTER(1+3)", x, y, TEXT_MINI_COLOR_BLUE);
 			else
-				TextMiniXY("AUTOFILTER(2+4)",x,y,1);
+				TextMiniXY("AUTOFILTER(2+4)", x, y, TEXT_MINI_COLOR_BLUE);
 			x += 16*8;
 		}
 	}
@@ -7197,25 +7224,25 @@ BOOL CSong::DrawInfo()
 	{
 		if (g==2)
 		{
-			TextMiniXY("BASS16(2+1)",x,y,1);
+			TextMiniXY("BASS16(2+1)", x, y, TEXT_MINI_COLOR_BLUE);
 			x += 12*8;
 		}
 		else
 		if (g==4)
 		{
-			TextMiniXY("BASS16(4+3)",x,y,1);
+			TextMiniXY("BASS16(4+3)", x, y, TEXT_MINI_COLOR_BLUE);
 			x += 12*8;
 		}
 		else
 		{
-			TextMiniXY("NO BASS16",x,y,0);	//gray
+			TextMiniXY("NO BASS16", x, y, TEXT_MINI_COLOR_GRAY);;
 			x += 10*8;
 		}
 	}
 
 	if (flag&IF_PORTAMENTO)
 	{
-		TextMiniXY("PORTAMENTO",x,y,1);
+		TextMiniXY("PORTAMENTO", x, y, TEXT_MINI_COLOR_BLUE);
 		x += 11*8;
 	}
 	if (flag&IF_AUDCTL)
@@ -7230,7 +7257,7 @@ BOOL CSong::DrawInfo()
 				  | (ti.par[PAR_AUDCTL6]<<6)
 				  | (ti.par[PAR_AUDCTL7]<<7);
 		sprintf(s,"AUDCTL:%02X",audctl);
-		TextMiniXY(s,x,y,1);
+		TextMiniXY(s, x, y, TEXT_MINI_COLOR_BLUE);
 		x += 6*8;
 	}
 
@@ -7292,7 +7319,7 @@ BOOL CSong::DrawPlaytimecounter(CDC *pDC = NULL)
 	}
 
 	timstr[5] = 0; //null
-	TextMiniXY(timstr,PLAYTC_X,PLAYTC_Y,(m_play)? 2 : 0);
+	TextMiniXY(timstr, PLAYTC_X, PLAYTC_Y, (m_play) ? TEXT_MINI_COLOR_WHITE : TEXT_MINI_COLOR_GRAY);
 	if (pDC) pDC->BitBlt((PLAYTC_X*sp)/100, (PLAYTC_Y*sp)/100, (PLAYTC_S*sp)/100, (PLAYTC_H*sp)/100, g_mem_dc, (PLAYTC_X*sp)/100, (PLAYTC_Y*sp)/100, SRCCOPY);
 	return 1;
 }
@@ -7408,8 +7435,8 @@ BOOL CSong::DrawAnalyzer(CDC* pDC = NULL)
 
 			if (g_viewpokeyregs)
 			{
-				NumberMiniXY(audf, ANALYZER_X + 10 + a + 17, ANALYZER_Y - 8, 0);
-				NumberMiniXY(audc, ANALYZER_X + 36 + a + 17, ANALYZER_Y - 8, 0);
+				NumberMiniXY(audf, ANALYZER_X + 10 + a + 17, ANALYZER_Y - 8, TEXT_MINI_COLOR_GRAY);
+				NumberMiniXY(audc, ANALYZER_X + 36 + a + 17, ANALYZER_Y - 8, TEXT_MINI_COLOR_GRAY);
 			}
 		}
 		if (g_viewpokeyregs)
@@ -7519,7 +7546,6 @@ BOOL CSong::DrawAnalyzer(CDC* pDC = NULL)
 			int audnum = (i * 2) + minus;
 			char s[2];
 			char p[12];
-			char c[3];
 			char n[4];
 			double PITCH = 0;
 
@@ -7560,28 +7586,28 @@ BOOL CSong::DrawAnalyzer(CDC* pDC = NULL)
 
 			if (g_viewpokeyregs)
 			{
-				TextMiniXY("$D200: $   $     PITCH = $     (         HZ ---  +  ), VOL = $ , DIST = $ ,", ANALYZER3_X, ANALYZER3_Y + a, 0);
-				TextMiniXY("$D208: $  ", ANALYZER3_X, ANALYZER3_Y + gap2 + 48, 0);
-				TextMiniXY("$D20F: $  ", ANALYZER3_X, ANALYZER3_Y + gap2 + 48 + 8, 0);
+				TextMiniXY("$D200: $   $     PITCH = $     (         HZ ---  +  ), VOL = $ , DIST = $ ,", ANALYZER3_X, ANALYZER3_Y + a, TEXT_MINI_COLOR_GRAY);
+				TextMiniXY("$D208: $  ", ANALYZER3_X, ANALYZER3_Y + gap2 + 48, TEXT_MINI_COLOR_GRAY);
+				TextMiniXY("$D20F: $  ", ANALYZER3_X, ANALYZER3_Y + gap2 + 48 + 8, TEXT_MINI_COLOR_GRAY);
 
 				if (CLOCK_15)	//15khz
-					TextMiniXY("15KHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, 1);
+					TextMiniXY("15KHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
 				else
-					TextMiniXY("64KHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, 1);
+					TextMiniXY("64KHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
 
 				if (CLOCK_179)
-					TextMiniXY("1.79MHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, 1);
+					TextMiniXY("1.79MHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
 
 				if (JOIN_16BIT || JOIN_64KHZ || JOIN_15KHZ)
-					TextMiniXY("16-BIT", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, 1);
+					TextMiniXY("16-BIT", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
 
 				/*
 				if (JOIN_16BIT)
-					TextMiniXY("16-BIT, 1.79MHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, 1);
+					TextMiniXY("16-BIT, 1.79MHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
 				else if (JOIN_64KHZ)
-					TextMiniXY("16-BIT, 64KHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, 1);
+					TextMiniXY("16-BIT, 64KHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
 				else if (JOIN_15KHZ)
-					TextMiniXY("16-BIT, 15KHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, 1);
+					TextMiniXY("16-BIT, 15KHZ", ANALYZER3_X + 8 * 76, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
 				*/
 
 				/*
@@ -7593,9 +7619,9 @@ BOOL CSong::DrawAnalyzer(CDC* pDC = NULL)
 					IS_VALID = ((audf + modoffset) % v_modulo == 0) ? 0 : 1;
 					if (IS_VALID)
 					{
-						if (IS_BUZZY_DIST_C) TextMiniXY("BUZZY", ANALYZER3_X + 8 * 84, ANALYZER3_Y + a, 1);
-						else if (IS_UNSTABLE_DIST_C) TextMiniXY("UNSTABLE", ANALYZER3_X + 8 * 84, ANALYZER3_Y + a, 1);
-						else TextMiniXY("GRITTY", ANALYZER3_X + 8 * 84, ANALYZER3_Y + a, 1);
+						if (IS_BUZZY_DIST_C) TextMiniXY("BUZZY", ANALYZER3_X + 8 * 84, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
+						else if (IS_UNSTABLE_DIST_C) TextMiniXY("UNSTABLE", ANALYZER3_X + 8 * 84, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
+						else TextMiniXY("GRITTY", ANALYZER3_X + 8 * 84, ANALYZER3_Y + a, TEXT_MINI_COLOR_BLUE);
 					}
 				}
 				*/
@@ -7603,61 +7629,61 @@ BOOL CSong::DrawAnalyzer(CDC* pDC = NULL)
 				if (HPF_CH13)
 				{
 					if (SAWTOOTH && !SAWTOOTH_INVERTED)
-						TextMiniXY("CH1: HIGH PASS FILTER, SAWTOOTH", ANALYZER3_X + 8 * 32, ANALYZER3_Y + gap2 + 48, 1);
+						TextMiniXY("CH1: HIGH PASS FILTER, SAWTOOTH", ANALYZER3_X + 8 * 32, ANALYZER3_Y + gap2 + 48, TEXT_MINI_COLOR_BLUE);
 					else
-					if (SAWTOOTH && SAWTOOTH_INVERTED)
-						TextMiniXY("CH1: HIGH PASS FILTER, SAWTOOTH (INVERTED)", ANALYZER3_X + 8 * 32, ANALYZER3_Y + gap2 + 48, 1);
-					else
-						TextMiniXY("CH1: HIGH PASS FILTER", ANALYZER3_X + 8 * 32, ANALYZER3_Y + gap2 + 48, 1);
+						if (SAWTOOTH && SAWTOOTH_INVERTED)
+							TextMiniXY("CH1: HIGH PASS FILTER, SAWTOOTH (INVERTED)", ANALYZER3_X + 8 * 32, ANALYZER3_Y + gap2 + 48, TEXT_MINI_COLOR_BLUE);
+						else
+							TextMiniXY("CH1: HIGH PASS FILTER", ANALYZER3_X + 8 * 32, ANALYZER3_Y + gap2 + 48, TEXT_MINI_COLOR_BLUE);
 				}
 
 				if (HPF_CH24)
-					TextMiniXY("CH2: HIGH PASS FILTER", ANALYZER3_X + 8 * 32, ANALYZER3_Y + gap2 + 48 + 8, 1);
+					TextMiniXY("CH2: HIGH PASS FILTER", ANALYZER3_X + 8 * 32, ANALYZER3_Y + gap2 + 48 + 8, TEXT_MINI_COLOR_BLUE);
 
 				if (POLY9)
-					TextMiniXY("POLY9 ENABLED", ANALYZER3_X + 8 * 11, ANALYZER3_Y + gap2 + 48, 1);
+					TextMiniXY("POLY9 ENABLED", ANALYZER3_X + 8 * 11, ANALYZER3_Y + gap2 + 48, TEXT_MINI_COLOR_BLUE);
 
 				if (TWO_TONE)
-					TextMiniXY("CH1: TWO TONE FILTER", ANALYZER3_X + 8 * 11, ANALYZER3_Y + gap2 + 48 + 8, 1);
+					TextMiniXY("CH1: TWO TONE FILTER", ANALYZER3_X + 8 * 11, ANALYZER3_Y + gap2 + 48 + 8, TEXT_MINI_COLOR_BLUE);
 
 				if (REVERSE_16)
 				{
 					if (i == 0 || i == 4)
-						TextMiniXY("CH1: REVERSE-16 OUTPUT", ANALYZER3_X + 8 * 54, ANALYZER3_Y + gap2 + 48, 1);
+						TextMiniXY("CH1: REVERSE-16 OUTPUT", ANALYZER3_X + 8 * 54, ANALYZER3_Y + gap2 + 48, TEXT_MINI_COLOR_BLUE);
 					else if (i == 2 || i == 6)
-						TextMiniXY("CH3: REVERSE-16 OUTPUT", ANALYZER3_X + 8 * 54, ANALYZER3_Y + gap2 + 48 + 8, 1);
+						TextMiniXY("CH3: REVERSE-16 OUTPUT", ANALYZER3_X + 8 * 54, ANALYZER3_Y + gap2 + 48 + 8, TEXT_MINI_COLOR_BLUE);
 				}
 
-				NumberMiniXY(audf, ANALYZER3_X + 8 * 8, ANALYZER3_Y + a, 2);
-				NumberMiniXY(audc, ANALYZER3_X + 8 * 12, ANALYZER3_Y + a, 2);
-				NumberMiniXY(pitch, ANALYZER3_X + 8 * 26, ANALYZER3_Y + a, 2);
+				NumberMiniXY(audf, ANALYZER3_X + 8 * 8, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);
+				NumberMiniXY(audc, ANALYZER3_X + 8 * 12, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);
+				NumberMiniXY(pitch, ANALYZER3_X + 8 * 26, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);
 
-				if ((JOIN_16BIT || JOIN_64KHZ || JOIN_15KHZ ) && !vol2)	//16-bit without Reverse-16 output
-					NumberMiniXY(audf2, ANALYZER3_X + 8 * 28, ANALYZER3_Y + a, 2);
+				if ((JOIN_16BIT || JOIN_64KHZ || JOIN_15KHZ) && !vol2)	//16-bit without Reverse-16 output
+					NumberMiniXY(audf2, ANALYZER3_X + 8 * 28, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);
 
-				NumberMiniXY(vol, ANALYZER3_X + 8 * 61, ANALYZER3_Y + a, 2);
-				NumberMiniXY(dist, ANALYZER3_X + 8 * 73, ANALYZER3_Y + a, 2);
-				if (dist == 0xf0) TextMiniXY("e", ANALYZER3_X + 8 * 73, ANALYZER3_Y + a, 2);	//empty tile
-				NumberMiniXY(audctl, ANALYZER3_X + 8 * 8, ANALYZER3_Y + gap2 + 48, 2);
-				NumberMiniXY(skctl, ANALYZER3_X + 8 * 8, ANALYZER3_Y + gap2 + 48 + 8, 2);
+				NumberMiniXY(vol, ANALYZER3_X + 8 * 61, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);
+				NumberMiniXY(dist, ANALYZER3_X + 8 * 73, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);
+				if (dist == 0xf0) TextMiniXY("e", ANALYZER3_X + 8 * 73, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);	//empty tile
+				NumberMiniXY(audctl, ANALYZER3_X + 8 * 8, ANALYZER3_Y + gap2 + 48, TEXT_MINI_COLOR_WHITE);
+				NumberMiniXY(skctl, ANALYZER3_X + 8 * 8, ANALYZER3_Y + gap2 + 48 + 8, TEXT_MINI_COLOR_WHITE);
 
-				TextMiniXY(p, ANALYZER3_X + 8 * 32, ANALYZER3_Y + a, 2);	//pitch calculation
-				TextMiniXY("$", ANALYZER3_X + 8 * 61, ANALYZER3_Y + a, 0);	//character $ to overwrite the left volume nybble
-				TextMiniXY(",", ANALYZER3_X + 8 * 74, ANALYZER3_Y + a, 0);	//character , to overwrite the right distortion nybble
+				TextMiniXY(p, ANALYZER3_X + 8 * 32, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);	//pitch calculation
+				TextMiniXY("$", ANALYZER3_X + 8 * 61, ANALYZER3_Y + a, TEXT_MINI_COLOR_GRAY);	//character $ to overwrite the left volume nybble
+				TextMiniXY(",", ANALYZER3_X + 8 * 74, ANALYZER3_Y + a, TEXT_MINI_COLOR_GRAY);	//character , to overwrite the right distortion nybble
 
 				sprintf(s, "%d", audnum);
-				TextMiniXY(s, ANALYZER3_X + 8 * 4, ANALYZER3_Y + a, 0);		//register number
+				TextMiniXY(s, ANALYZER3_X + 8 * 4, ANALYZER3_Y + a, TEXT_MINI_COLOR_GRAY);		//register number
 
 				if (IS_RIGHT_POKEY)
 				{
-					TextMiniXY("POKEY REGISTERS (LEFT)", ANALYZER3_X, ANALYZER3_Y, 0);
-					TextMiniXY("POKEY REGISTERS (RIGHT)", ANALYZER3_X, ANALYZER3_Y + 96, 0);
+					TextMiniXY("POKEY REGISTERS (LEFT)", ANALYZER3_X, ANALYZER3_Y, TEXT_MINI_COLOR_GRAY);
+					TextMiniXY("POKEY REGISTERS (RIGHT)", ANALYZER3_X, ANALYZER3_Y + 96, TEXT_MINI_COLOR_GRAY);
 
-					TextMiniXY("1", ANALYZER3_X + 8 * 3, ANALYZER3_Y + a, 0);
-					TextMiniXY("1", ANALYZER3_X + 8 * 3, ANALYZER3_Y + gap2 + 48, 0);
-					TextMiniXY("1", ANALYZER3_X + 8 * 3, ANALYZER3_Y + gap2 + 48 + 8, 0);
+					TextMiniXY("1", ANALYZER3_X + 8 * 3, ANALYZER3_Y + a, TEXT_MINI_COLOR_GRAY);
+					TextMiniXY("1", ANALYZER3_X + 8 * 3, ANALYZER3_Y + gap2 + 48, TEXT_MINI_COLOR_GRAY);
+					TextMiniXY("1", ANALYZER3_X + 8 * 3, ANALYZER3_Y + gap2 + 48 + 8, TEXT_MINI_COLOR_GRAY);
 				}
-				else TextMiniXY("POKEY REGISTERS", ANALYZER3_X, ANALYZER3_Y, 0);
+				else TextMiniXY("POKEY REGISTERS", ANALYZER3_X, ANALYZER3_Y, TEXT_MINI_COLOR_GRAY);
 
 				double tuning = g_basetuning;	//defined in Tuning.cpp through initialisation using input parameter
 				int basenote = g_basenote;
@@ -7667,35 +7693,37 @@ BOOL CSong::DrawAnalyzer(CDC* pDC = NULL)
 				int tracks = (g_tracks4_8 == 8) ? 8 : 4;
 				char t[12] = { 0 };
 
-				TextMiniXY("A- TUNING:       HZ,", ANALYZER3_X, ANALYZER3_Y + 8 * 9, 0);
+				TextMiniXY("A- TUNING:       HZ,", ANALYZER3_X, ANALYZER3_Y + 8 * 9, TEXT_MINI_COLOR_GRAY);
 				snprintf(t, 10, "%3.2f", tuning);
-				TextMiniXY(t, ANALYZER3_X + 8 * 11, ANALYZER3_Y + 8 * 9, 2);
+				TextMiniXY(t, ANALYZER3_X + 8 * 11, ANALYZER3_Y + 8 * 9, TEXT_MINI_COLOR_WHITE);
 
 				n[0] = notes[reverse_basenote][0];
 				n[1] = notes[reverse_basenote][1];
 				n[2] = 0;
 
-				TextMiniXY(n, ANALYZER3_X, ANALYZER3_Y + 8 * 9, 0);	//overwrite A- to the given basenote
+				TextMiniXY(n, ANALYZER3_X, ANALYZER3_Y + 8 * 9, TEXT_MINI_COLOR_GRAY);	//overwrite A- to the given basenote
 
-				if (g_ntsc) TextMiniXY("NTSC", ANALYZER3_X + 8 * 21, ANALYZER3_Y + 8 * 9, 1);
-				else TextMiniXY("PAL", ANALYZER3_X + 8 * 21, ANALYZER3_Y + 8 * 9, 1);
+				if (g_ntsc) TextMiniXY("NTSC", ANALYZER3_X + 8 * 21, ANALYZER3_Y + 8 * 9, TEXT_MINI_COLOR_BLUE);
+				else TextMiniXY("PAL", ANALYZER3_X + 8 * 21, ANALYZER3_Y + 8 * 9, TEXT_MINI_COLOR_BLUE);
 
-				TextMiniXY("FREQ17:        HZ, MAXSCREENCYCLES:      , G_TRACKS4_8:", ANALYZER3_X, ANALYZER3_Y + 8 * 10, 0);
+				TextMiniXY("FREQ17:        HZ, MAXSCREENCYCLES:      , G_TRACKS4_8:", ANALYZER3_X, ANALYZER3_Y + 8 * 10, TEXT_MINI_COLOR_GRAY);
 				snprintf(t, 8, "%d", FREQ_17);
-				TextMiniXY(t, ANALYZER3_X + 8 * 8, ANALYZER3_Y + 8 * 10, 2);
+				TextMiniXY(t, ANALYZER3_X + 8 * 8, ANALYZER3_Y + 8 * 10, TEXT_MINI_COLOR_WHITE);
 				snprintf(t, 8, "%d", cycles);
-				TextMiniXY(t, ANALYZER3_X + 8 * 36, ANALYZER3_Y + 8 * 10, 2);
+				TextMiniXY(t, ANALYZER3_X + 8 * 36, ANALYZER3_Y + 8 * 10, TEXT_MINI_COLOR_WHITE);
 				snprintf(t, 2, "%d", tracks);
-				TextMiniXY(t, ANALYZER3_X + 8 * 56, ANALYZER3_Y + 8 * 10, 2);
+				TextMiniXY(t, ANALYZER3_X + 8 * 56, ANALYZER3_Y + 8 * 10, TEXT_MINI_COLOR_WHITE);
 
 				if (PITCH)	//if null is read, there is nothing to show. Volume Only mode or invalid parameters may return this
 				{
 					if (JOIN_WRONG)	//16-bit, but wrong channels, and the volume is 0
 					{
-						TextMiniXY("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", ANALYZER3_X + 8 * 17, ANALYZER3_Y + a, 0);	//masking parts of the line,cursed patch but that works so who cares
+						TextMiniXY("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", ANALYZER3_X + 8 * 17, ANALYZER3_Y + a, TEXT_MINI_COLOR_GRAY);	//masking parts of the line,cursed patch but that works so who cares
 					}
 					else
 					{
+						char szBuffer[16];
+
 						//most of the lines below could get some improvements...
 						double centnum = 1200 * log2(PITCH / tuning);
 						int notenum = (int)round(centnum * 0.01) + 60;
@@ -7703,21 +7731,21 @@ BOOL CSong::DrawAnalyzer(CDC* pDC = NULL)
 						int octave = (notenum - basenote) / 12;
 						int cents = (int)round(centnum - (notenum - 60) * 100);
 
-						snprintf(c, 4, "%03d", cents);
-						TextMiniXY(c, ANALYZER3_X + 8 * 49, ANALYZER3_Y + a, 2);
+						snprintf(szBuffer, 4, "%03d", cents);
+						TextMiniXY(szBuffer, ANALYZER3_X + 8 * 49, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);
 
 						if (cents >= 0)
-							TextMiniXY("+", ANALYZER3_X + 8 * 49, ANALYZER3_Y + a, 0);
+							TextMiniXY("+", ANALYZER3_X + 8 * 49, ANALYZER3_Y + a, TEXT_MINI_COLOR_GRAY);
 						else
-							TextMiniXY("-", ANALYZER3_X + 8 * 49, ANALYZER3_Y + a, 0);
+							TextMiniXY("-", ANALYZER3_X + 8 * 49, ANALYZER3_Y + a, TEXT_MINI_COLOR_GRAY);
 
 						n[0] = notes[note][0];
 						n[1] = notes[note][1];
 						n[2] = 0;
 
-						sprintf(c, "%1d", octave);
-						TextMiniXY(n, ANALYZER3_X + 8 * 44, ANALYZER3_Y + a, 2);
-						TextMiniXY(c, ANALYZER3_X + 8 * 46, ANALYZER3_Y + a, 2);
+						sprintf(szBuffer, "%1d", octave);
+						TextMiniXY(n, ANALYZER3_X + 8 * 44, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);
+						TextMiniXY(szBuffer, ANALYZER3_X + 8 * 46, ANALYZER3_Y + a, TEXT_MINI_COLOR_WHITE);
 
 					}
 				}
@@ -7735,18 +7763,18 @@ BOOL CSong::DrawAnalyzer(CDC* pDC = NULL)
 		{
 			//larger font...
 			//GetAtariMemHexStr(0xB200 + (0x10 * d), 16);	//Distortion C page
-			//TextXY(g_debugmem, ANALYZER3_X, ANALYZER3_Y + 240 + 16 * d + 8 + gap, 0);
+			//TextXY(g_debugmem, ANALYZER3_X, ANALYZER3_Y + 240 + 16 * d + 8 + gap, TEXT_COLOR_WHITE);
 			gap += (d % 8 == 0) ? 8 : 0;
 			page += (d % 8 == 0 && d != 0) ? 1 : 0;
 			gap2 = 16 * page;
 			GetAtariMemHexStr(0xB000 + 0x20 * d, 32); 
-			TextMiniXY(g_debugmem, ANALYZER3_X, ANALYZER3_Y + 192 + 8 * d + 8 + gap + gap2, 2);
+			TextMiniXY(g_debugmem, ANALYZER3_X, ANALYZER3_Y + 192 + 8 * d + 8 + gap + gap2, TEXT_MINI_COLOR_WHITE);
 
 			if (d % 8 == 0)
 			{
-				TextMiniXY("G_ATARIMEM (      ):", ANALYZER3_X, ANALYZER3_Y + 192 + 8 * d + gap + gap2 - 8, 0);
-				NumberMiniXY(page, ANALYZER3_X + 8 * 14, ANALYZER3_Y + 192 + 8 * d + gap + gap2 - 8, 2);
-				TextMiniXY("0XB 00", ANALYZER3_X + 8 * 12, ANALYZER3_Y + 192 + 8 * d + gap + gap2 - 8, 2);
+				TextMiniXY("G_ATARIMEM (      ):", ANALYZER3_X, ANALYZER3_Y + 192 + 8 * d + gap + gap2 - 8, TEXT_MINI_COLOR_GRAY);
+				NumberMiniXY(page, ANALYZER3_X + 8 * 14, ANALYZER3_Y + 192 + 8 * d + gap + gap2 - 8, TEXT_MINI_COLOR_WHITE);
+				TextMiniXY("0XB 00", ANALYZER3_X + 8 * 12, ANALYZER3_Y + 192 + 8 * d + gap + gap2 - 8, TEXT_MINI_COLOR_WHITE);
 			}
 		}
 		if (pDC) pDC->BitBlt((ANALYZER3_X * sp) / 100, ((ANALYZER3_Y + 192) * sp) / 100, ((680 + (8 * 42)) * sp) / 100, (432 * sp) / 100, g_mem_dc, (ANALYZER3_X * sp) / 100, ((ANALYZER3_Y + 192) * sp) / 100, SRCCOPY);

--- a/cpp_src/r_music.h
+++ b/cpp_src/r_music.h
@@ -343,7 +343,7 @@ public:
 private:
 	BOOL DrawName(int it);
 	BOOL DrawPar(int p,int it);
-	BOOL DrawEnv(int e,int it);
+	void DrawEnv(int e,int it);
 	BOOL DrawTab(int p,int it);
 
 	BYTE m_iflag[INSTRSNUM];


### PR DESCRIPTION
…resize a new one was created.

Fixed a memory overflow in CSong::DrawAnalyzer().
Moved most of global.h into global.cpp. This has the advantage that global.h can now be included in other files.
Added required includes to some files and removed extra "extern" definitions from lots of header files.
Added text color definitions to global.h and updated the color usage variables in r_music.cpp to use the new #defines
Added a SCALE(x) #define to make the StretchBlt code easier to read.
TODO:
Clean up the remaining extra "extern" definitions.
Fix tight code integration of SAP-R compressor.
Restructure the12000 line "r_music.cpp" file to break it up into functional units: Undo, Tracks, Instruments, Song, TrackClipboard
Add 6502 ASM source compilation to the project, and make the integration between the two systems a bit more dynamic.