### PR TITLE
Allign C/C++ language settings in debug configuration

### DIFF
--- a/cpp_src/Rmt.vcxproj
+++ b/cpp_src/Rmt.vcxproj
@@ -267,6 +267,8 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <AdditionalDependencies>dsound.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
I adjusted C/C++ Language Standard in Debug configuration as mentioned here:
https://github.com/VinsCool/RASTER-Music-Tracker/issues/8#issuecomment-1546887185