### PR TITLE
Fix for modern Visual Studio

### DIFF
--- a/cpp_src/Song.cpp
+++ b/cpp_src/Song.cpp
@@ -1,5 +1,6 @@
 #include "StdAfx.h"
 #include <fstream>
+#include <thread>
 #include <chrono>
 
 #include "GuiHelpers.h"


### PR DESCRIPTION
Visual Studio 2022 throws an error "Name followed by :: must be a class or namespace name" in Song.cpp at line 46. Including `thread` seems to fix the issue.